### PR TITLE
parsing latitude and longitude in wb.get_countries

### DIFF
--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -104,6 +104,8 @@ class TestWB(tm.TestCase):
         result = get_countries()
         self.assertTrue('Zimbabwe' in list(result['name']))
         self.assertTrue(len(result) > 100)
+        self.assertTrue(pandas.notnull(result.latitude.mean()))
+        self.assertTrue(pandas.notnull(result.longitude.mean()))
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas_datareader/wb.py
+++ b/pandas_datareader/wb.py
@@ -213,6 +213,9 @@ def _get_data(indicator="NY.GNS.ICTR.GN.ZS", country='US',
 
 def get_countries():
     '''Query information about countries
+    
+    Provides information such as: 
+        country code, region, income level, capital city, latitude and longitude
     '''
     url = 'http://api.worldbank.org/countries/?per_page=1000&format=json'
     with urlopen(url) as response:
@@ -223,6 +226,8 @@ def get_countries():
     data.incomeLevel = [x['value'] for x in data.incomeLevel]
     data.lendingType = [x['value'] for x in data.lendingType]
     data.region = [x['value'] for x in data.region]
+    data.latitude = [float(x) if x != "" else np.nan for x in data.latitude]
+    data.longitude = [float(x) if x != "" else np.nan for x in data.longitude]
     data = data.rename(columns={'id': 'iso3c', 'iso2Code': 'iso2c'})
     return data
 


### PR DESCRIPTION
World Bank provides latitude and longitude as strings (and an empty string as a missing value). It's inconvenient so, I parse it to floats. Additionally, I added some description to the `wb.get_countries` function.