### PR TITLE
ENH: Add functions to top level API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,5 +38,11 @@ For now, you must replace your imports from ``pandas.io`` with ``pandas_dataread
    from pandas.io import data, wb # becomes
    from pandas_datareader import data, wb
 
+Many functions from the data module have been included in the top level API.
+
+.. code-block:: python
+
+   import pandas_datareader as pdr
+   pdr.get_data_yahoo('AAPL')
 
 See the `pandas-datareader documentation <http://pandas-datareader.readthedocs.org/>`_ for more details.

--- a/pandas_datareader/__init__.py
+++ b/pandas_datareader/__init__.py
@@ -1,1 +1,4 @@
 __version__ = version = '0.2.1'
+
+from .data import (get_components_yahoo, get_data_famafrench, get_data_google, get_data_yahoo,
+        get_data_yahoo_actions, get_quote_google, get_quote_yahoo, DataReader, Options)

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -19,7 +19,6 @@ from pandas_datareader.famafrench import FamaFrenchReader
 from pandas_datareader.oecd import OECDReader
 
 
-# ToDo: deprecate
 def get_data_fred(*args, **kwargs):
     return FredReader(*args, **kwargs).read()
 


### PR DESCRIPTION
#117 

Easy fix for now, remains backwards compatible.  Now you can tab into the key functions and DataReader.

Thoughts?