### PR TITLE
Added `data_source='yahoo-dividends'` option to DataReader.

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -61,6 +61,17 @@ Historical corporate actions (Dividends and Stock Splits) with ex-dates from Yah
 
   web.DataReader('AAPL', 'yahoo-actions', start, end)
 
+Historical dividends from Yahoo! Finance.
+
+.. ipython:: python
+
+    import pandas_datareader.data as web
+    import datetime
+    start = datetime.datetime(2010, 1, 1)
+    end = datetime.datetime(2013, 1, 27)
+    f = web.DataReader("F", 'yahoo-dividends', start, end)
+    f
+
 .. _remote_data.yahoo_options:
 
 Yahoo! Finance Options

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -18,6 +18,6 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.2.2.txt
 .. include:: whatsnew/v0.2.1.txt
 .. include:: whatsnew/v0.2.0.txt
-

--- a/docs/source/whatsnew/v0.2.2.txt
+++ b/docs/source/whatsnew/v0.2.2.txt
@@ -1,0 +1,31 @@
+.. _whatsnew_022:
+
+v0.2.2 (XXX)
+----------------------------
+
+This is a minor release from 0.2.1 and includes new features and a number of bug fixes.
+
+
+Highlights include:
+
+
+.. contents:: What's new in v0.2.2
+    :local:
+    :backlinks: none
+
+.. _whatsnew_022.enhancements:
+
+New features
+~~~~~~~~~~~~
+
+- ``DataReader`` now supports dividend only pulls from Yahoo! Finance, see :ref:`here<remote_data.yahoo>` (:issue:`138`).
+
+.. _whatsnew_022.api_breaking:
+
+Backwards incompatible API changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _whatsnew_022.bug_fixes:
+
+Bug Fixes
+~~~~~~~~~

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -52,7 +52,8 @@ def DataReader(name, data_source=None, start=None, end=None,
         the name of the dataset. Some data sources (yahoo, google, fred) will
         accept a list of names.
     data_source: {str, None}
-        the data source ("yahoo", "yahoo-actions", "google", "fred", or "ff")
+        the data source ("yahoo", "yahoo-actions", "yahoo-dividends",
+        "google", "fred", or "ff")
     start : {datetime, None}
         left boundary for range (defaults to 1/1/2010)
     end : {datetime, None}
@@ -96,6 +97,11 @@ def DataReader(name, data_source=None, start=None, end=None,
         return YahooActionReader(symbols=name, start=start, end=end,
                                  retry_count=retry_count, pause=pause,
                                  session=session).read()
+    elif data_source == "yahoo-dividends":
+        return YahooDailyReader(symbols=name, start=start, end=end,
+                                adjust_price=False, chunksize=25,
+                                retry_count=retry_count, pause=pause,
+                                session=session, interval='v').read()
 
     elif data_source == "google":
         return GoogleDailyReader(symbols=name, start=start, end=end,

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -512,6 +512,10 @@ class TestDataReader(tm.TestCase):
         gs = DataReader("GS", "yahoo")
         assert isinstance(gs, DataFrame)
 
+    def test_read_yahoo_dividends(self):
+        gs = DataReader("GS", "yahoo-dividends")
+        assert isinstance(gs, DataFrame)
+
     def test_read_google(self):
         gs = DataReader("GS", "google")
         assert isinstance(gs, DataFrame)


### PR DESCRIPTION
The existing dividend support pulls dividends as part of actions, but it's often desirable (for me anyway) to have just the dividends (and to pull a large number of symbols). The functionality is already there in `YahooDailyReader`, and this PR just creates an option that exposes it in `DataReader`.