### PR TITLE
BLD: drop python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 
 env:
-  - PYTHON=2.6 PANDAS=0.13.1
   - PYTHON=2.7 PANDAS=0.15.1
   - PYTHON=3.3 PANDAS=0.14.1
   - PYTHON=3.4 PANDAS=0.16.2

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Cython',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',


### PR DESCRIPTION
Should (at least partially) fix https://github.com/pydata/pandas-datareader/issues/160