### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Up to date remote data access for pandas, works for multiple versions of pandas.
     :target: https://coveralls.io/r/pydata/pandas-datareader
 
 .. image:: https://readthedocs.org/projects/pandas-datareader/badge/?version=latest
-    :target: http://pandas-datareader.readthedocs.org/en/latest/
+    :target: https://pandas-datareader.readthedocs.io/en/latest/
 
 .. image:: https://landscape.io/github/pydata/pandas-datareader/master/landscape.svg?style=flat
    :target: https://landscape.io/github/pydata/pandas-datareader/master
@@ -63,4 +63,4 @@ Many functions from the data module have been included in the top level API.
    import pandas_datareader as pdr
    pdr.get_data_yahoo('AAPL')
 
-See the `pandas-datareader documentation <http://pandas-datareader.readthedocs.org/>`_ for more details.
+See the `pandas-datareader documentation <https://pandas-datareader.readthedocs.io/>`_ for more details.

--- a/docs/source/cache.rst
+++ b/docs/source/cache.rst
@@ -42,4 +42,4 @@ A `SQLite <https://www.sqlite.org/>`_ file named ``cache.sqlite`` will be create
 directory, storing the request until the expiry date.
 
 For additional information on using requests-cache, see the
-`documentation <http://requests-cache.readthedocs.org/>`_.
+`documentation <https://requests-cache.readthedocs.io/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.