### PR TITLE
dealing with OANDA returning strings for currency above 1000

### DIFF
--- a/pandas_datareader/oanda.py
+++ b/pandas_datareader/oanda.py
@@ -39,14 +39,14 @@ def get_oanda_currency_historical_rates(start, end, quote_currency="USD", base_c
     skiprows = 4
     skipfooter = 4
     usecols = range(len(base_currency) + 1)
-    df = pd.read_csv(StringIO(response.text), parse_dates=[0], skiprows=skiprows, skipfooter=skipfooter, usecols=usecols, engine='python')
+    df = pd.read_csv(StringIO(response.text), parse_dates=[0], skiprows=skiprows, skipfooter=skipfooter,
+                     usecols=usecols, engine='python', thousands=',')
     df = df.rename(columns={
         "End Date": "Date",
     })
     df = df.set_index("Date")
     df = df[::-1]
-    df.replace(regex=True, inplace=True, to_replace=r',', value=r'')
-    df = df.astype('float64')
+
     if reversed:
         df.columns = pd.Index(df.columns.map(reverse_pair))
         df = 1 / df

--- a/pandas_datareader/oanda.py
+++ b/pandas_datareader/oanda.py
@@ -45,6 +45,8 @@ def get_oanda_currency_historical_rates(start, end, quote_currency="USD", base_c
     })
     df = df.set_index("Date")
     df = df[::-1]
+    df.replace(regex=True, inplace=True, to_replace=r',', value=r'')
+    df = df.astype('float64')
     if reversed:
         df.columns = pd.Index(df.columns.map(reverse_pair))
         df = 1 / df


### PR DESCRIPTION
simple 2 line add for converting all strings above 1000 to float. I first remove all the `,` and the convert to float64

try pulling this currency pair:

base_currency = "KRW'
quote_currency ='USD'

```
  File "C:\Anaconda2\lib\site-packages\pandas_datareader\oanda.py", line 52, in get_oanda_currency_historical_rates
    df = 1 / df
  File "C:\Anaconda2\lib\site-packages\pandas\core\ops.py", line 1097, in f
    return self._combine_const(other, na_op)
  File "C:\Anaconda2\lib\site-packages\pandas\core\frame.py", line 3555, in _combine_const
    raise_on_error=raise_on_error)
  File "C:\Anaconda2\lib\site-packages\pandas\core\internals.py", line 2911, in eval
    return self.apply('eval', **kwargs)
  File "C:\Anaconda2\lib\site-packages\pandas\core\internals.py", line 2890, in apply
    applied = getattr(b, f)(**kwargs)
  File "C:\Anaconda2\lib\site-packages\pandas\core\internals.py", line 1139, in eval
    result = handle_error()
  File "C:\Anaconda2\lib\site-packages\pandas\core\internals.py", line 1123, in handle_error
    (repr(other), str(detail)))
TypeError: Could not operate 1 with block values unsupported operand type(s) for /: 'int' and 'str'


```