### PR TITLE
IEX Implementation

### DIFF
--- a/pandas_datareader/__init__.py
+++ b/pandas_datareader/__init__.py
@@ -1,4 +1,6 @@
 __version__ = version = '0.5.0'
 
 from .data import (get_components_yahoo, get_data_famafrench, get_data_google, get_data_yahoo, get_data_enigma,  # noqa
-        get_data_yahoo_actions, get_quote_google, get_quote_yahoo, DataReader, Options)  # noqa
+        get_data_yahoo_actions, get_quote_google, get_quote_yahoo, get_tops_iex, get_last_iex, get_markets_iex,  # noqa
+        get_data_iex, get_summary_iex, get_records_iex, get_recent_iex, get_iex_symbols, get_iex_book,  # noqa
+        DataReader, Options)  # noqa

--- a/pandas_datareader/__init__.py
+++ b/pandas_datareader/__init__.py
@@ -2,5 +2,5 @@ __version__ = version = '0.5.0'
 
 from .data import (get_components_yahoo, get_data_famafrench, get_data_google, get_data_yahoo, get_data_enigma,  # noqa
         get_data_yahoo_actions, get_quote_google, get_quote_yahoo, get_tops_iex, get_last_iex, get_markets_iex,  # noqa
-        get_data_iex, get_summary_iex, get_records_iex, get_recent_iex, get_iex_symbols, get_iex_book,  # noqa
+        get_dailysummary_iex, get_summary_iex, get_records_iex, get_recent_iex, get_iex_symbols, get_iex_book,  # noqa
         DataReader, Options)  # noqa

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -137,13 +137,27 @@ class _BaseReader(object):
             # Get a new breadcrumb if necessary, in case ours is invalidated
             if isinstance(params, list) and 'crumb' in params:
                 params['crumb'] = self._get_crumb(self.retry_count)
+
+            # If our output error function returns True, exit the loop.
+            if self._output_error(response):
+                break
+
         if params is not None and len(params) > 0:
             url = url + "?" + urlencode(params)
+
         raise RemoteDataError('Unable to read URL: {0}'.format(url))
 
     def _get_crumb(self, *args):
         """ To be implemented by subclass """
         raise NotImplementedError("Subclass has not implemented method.")
+
+    def _output_error(self, out):
+        """If necessary, a service can implement an interpreter for any non-200 HTTP responses.
+
+        :param out: raw output from an HTTP request
+        :return: boolean
+        """
+        return False
 
     def _read_lines(self, out):
         rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -152,7 +152,8 @@ class _BaseReader(object):
         raise NotImplementedError("Subclass has not implemented method.")
 
     def _output_error(self, out):
-        """If necessary, a service can implement an interpreter for any non-200 HTTP responses.
+        """If necessary, a service can implement an interpreter for any non-200
+         HTTP responses.
 
         :param out: raw output from an HTTP request
         :return: boolean

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -15,7 +15,7 @@ from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.google.options import Options as GoogleOptions
 
 from pandas_datareader.iex.stats import DailySummaryReader as IEXHistorical
-from pandas_datareader.iex.stats import MonthlySummaryReader as IEXMonthlySummary
+from pandas_datareader.iex.stats import MonthlySummaryReader as IEXMonthSummary
 from pandas_datareader.iex.stats import RecentReader as IEXRecents
 from pandas_datareader.iex.stats import RecordsReader as IEXRecords
 from pandas_datareader.iex.market import MarketReader as IEXMarkets
@@ -82,7 +82,7 @@ def get_data_iex(*args, **kwargs):
 
 
 def get_summary_iex(*args, **kwargs):
-    return IEXMonthlySummary(*args, **kwargs).read()
+    return IEXMonthSummary(*args, **kwargs).read()
 
 
 def get_records_iex(*args, **kwargs):
@@ -174,13 +174,13 @@ def DataReader(name, data_source=None, start=None, end=None,
                                  session=session).read()
     elif data_source == "iex-tops":
         return IEXTops(symbols=name, start=start, end=end,
-                              retry_count=retry_count, pause=pause,
-                              session=session).read()
+                       retry_count=retry_count, pause=pause,
+                       session=session).read()
 
     elif data_source == "iex-last":
         return IEXLasts(symbols=name, start=start, end=end,
-                              retry_count=retry_count, pause=pause,
-                              session=session).read()
+                        retry_count=retry_count, pause=pause,
+                        session=session).read()
 
     elif data_source == "enigma":
         return EnigmaReader(datapath=name, api_key=access_key).read()

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -16,6 +16,7 @@ from pandas_datareader.google.options import Options as GoogleOptions
 
 from pandas_datareader.iex.stats import DailySummaryReader as IEXHistorical
 from pandas_datareader.iex.stats import MonthlySummaryReader as IEXMonthSummary
+from pandas_datareader.iex.deep import Deep as IEXDeep
 from pandas_datareader.iex.stats import RecentReader as IEXRecents
 from pandas_datareader.iex.stats import RecordsReader as IEXRecords
 from pandas_datareader.iex.market import MarketReader as IEXMarkets
@@ -95,6 +96,10 @@ def get_recent_iex(*args, **kwargs):
 
 def get_iex_symbols(*args, **kwargs):
     return IEXSymbols(*args, **kwargs).read()
+
+
+def get_iex_book(*args, **kwargs):
+    return IEXDeep(*args, **kwargs).read()
 
 
 def DataReader(name, data_source=None, start=None, end=None,
@@ -181,6 +186,11 @@ def DataReader(name, data_source=None, start=None, end=None,
         return IEXLasts(symbols=name, start=start, end=end,
                         retry_count=retry_count, pause=pause,
                         session=session).read()
+
+    elif data_source == "iex-book":
+        return IEXDeep(symbols=name, service="book", start=start, end=end,
+                       retry_count=retry_count, pause=pause,
+                       session=session).read()
 
     elif data_source == "enigma":
         return EnigmaReader(datapath=name, api_key=access_key).read()

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -14,6 +14,15 @@ from pandas_datareader.yahoo.components import _get_data as get_components_yahoo
 from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.google.options import Options as GoogleOptions
 
+from pandas_datareader.iex.stats import DailySummaryReader as IEXHistorical
+from pandas_datareader.iex.stats import MonthlySummaryReader as IEXMonthlySummary
+from pandas_datareader.iex.stats import RecentReader as IEXRecents
+from pandas_datareader.iex.stats import RecordsReader as IEXRecords
+from pandas_datareader.iex.market import MarketReader as IEXMarkets
+from pandas_datareader.iex.tops import LastReader as IEXLasts
+from pandas_datareader.iex.tops import TopsReader as IEXTops
+from pandas_datareader.iex.ref import SymbolsReader as IEXSymbols
+
 from pandas_datareader.eurostat import EurostatReader
 from pandas_datareader.fred import FredReader
 from pandas_datareader.famafrench import FamaFrenchReader
@@ -54,6 +63,38 @@ def get_quote_yahoo(*args, **kwargs):
 
 def get_quote_google(*args, **kwargs):
     return GoogleQuotesReader(*args, **kwargs).read()
+
+
+def get_tops_iex(*args, **kwargs):
+    return IEXTops(*args, **kwargs).read()
+
+
+def get_last_iex(*args, **kwargs):
+    return IEXLasts(*args, **kwargs).read()
+
+
+def get_markets_iex(*args, **kwargs):
+    return IEXMarkets(*args, **kwargs).read()
+
+
+def get_data_iex(*args, **kwargs):
+    return IEXHistorical(*args, **kwargs).read()
+
+
+def get_summary_iex(*args, **kwargs):
+    return IEXMonthlySummary(*args, **kwargs).read()
+
+
+def get_records_iex(*args, **kwargs):
+    return IEXRecords(*args, **kwargs).read()
+
+
+def get_recent_iex(*args, **kwargs):
+    return IEXRecents(*args, **kwargs).read()
+
+
+def get_iex_symbols(*args, **kwargs):
+    return IEXSymbols(*args, **kwargs).read()
 
 
 def DataReader(name, data_source=None, start=None, end=None,
@@ -131,6 +172,15 @@ def DataReader(name, data_source=None, start=None, end=None,
                                  chunksize=25,
                                  retry_count=retry_count, pause=pause,
                                  session=session).read()
+    elif data_source == "iex-tops":
+        return IEXTops(symbols=name, start=start, end=end,
+                              retry_count=retry_count, pause=pause,
+                              session=session).read()
+
+    elif data_source == "iex-last":
+        return IEXLasts(symbols=name, start=start, end=end,
+                              retry_count=retry_count, pause=pause,
+                              session=session).read()
 
     elif data_source == "enigma":
         return EnigmaReader(datapath=name, api_key=access_key).read()

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -92,7 +92,7 @@ def get_dailysummary_iex(*args, **kwargs):
         A datetime object - the beginning of the date range.
     :param end:
         A datetime object - the end of the date range.
-  
+
     Reference: https://www.iextrading.com/developer/docs/#historical-daily
 
     :return: DataFrame
@@ -107,7 +107,7 @@ def get_summary_iex(*args, **kwargs):
     related metrics for trades by lot size, security market cap, and venue.
     In the absence of parameters, this will return month-to-date statistics.
     For ranges spanning multiple months, this will return one row per month.
- 
+
     :param start:
         A datetime object - the beginning of the date range.
     :param end:

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -72,11 +72,11 @@ def get_markets_iex(*args, **kwargs):
     """
     Returns near-real time volume data across markets segregated by tape
     and including a percentage of overall volume during the session
-    
+
     This endpoint does not accept any parameters.
-    
+
     Reference: https://www.iextrading.com/developer/docs/#markets
-    
+
     :return: DataFrame
     """
     from pandas_datareader.iex.market import MarketReader
@@ -87,14 +87,14 @@ def get_dailysummary_iex(*args, **kwargs):
     """
     Returns a summary of daily market volume statistics. Without parameters,
     this will return the most recent trading session by default.
-    
-    :param start: 
+
+    :param start:
         A datetime object - the beginning of the date range.
     :param end:
         A datetime object - the end of the date range.
-        
+  
     Reference: https://www.iextrading.com/developer/docs/#historical-daily
-        
+
     :return: DataFrame
     """
     from pandas_datareader.iex.stats import DailySummaryReader
@@ -103,16 +103,16 @@ def get_dailysummary_iex(*args, **kwargs):
 
 def get_summary_iex(*args, **kwargs):
     """
-    Returns an aggregated monthly summary of market volume and a variety of 
+    Returns an aggregated monthly summary of market volume and a variety of
     related metrics for trades by lot size, security market cap, and venue.
     In the absence of parameters, this will return month-to-date statistics.
     For ranges spanning multiple months, this will return one row per month.
-        
-    :param start: 
+ 
+    :param start:
         A datetime object - the beginning of the date range.
     :param end:
         A datetime object - the end of the date range.
-        
+
     :return: DataFrame
     """
     from pandas_datareader.iex.stats import MonthlySummaryReader
@@ -124,9 +124,9 @@ def get_records_iex(*args, **kwargs):
     Returns the record value, record date, recent value, and 30-day average for
     market volume, # of symbols traded, # of routed trades and notional value.
     This function accepts no additional parameters.
-    
+
     Reference: https://www.iextrading.com/developer/docs/#records
-    
+
     :return: DataFrame
     """
     from pandas_datareader.iex.stats import RecordsReader
@@ -138,9 +138,9 @@ def get_recent_iex(*args, **kwargs):
     Returns market volume and trade routing statistics for recent sessions.
     Also reports IEX's relative market share, lit share volume and a boolean
     halfday indicator.
-    
+
     Reference: https://www.iextrading.com/developer/docs/#recent
-    
+
     :return: DataFrame
     """
     from pandas_datareader.iex.stats import RecentReader
@@ -151,9 +151,9 @@ def get_iex_symbols(*args, **kwargs):
     """
     Returns a list of all equity symbols available for trading on IEX. Accepts
     no additional parameters.
-    
+
     Reference: https://www.iextrading.com/developer/docs/#symbols
-    
+
     :return: DataFrame
     """
     from pandas_datareader.iex.ref import SymbolsReader
@@ -164,7 +164,7 @@ def get_iex_book(*args, **kwargs):
     """
     Returns an array of dictionaries with depth of book data from IEX for up to
     10 securities at a time. Returns a dictionary of the bid and ask books.
-    
+
     :param symbols:
         A string or list of strings of valid tickers
     :param service:
@@ -176,7 +176,7 @@ def get_iex_book(*args, **kwargs):
         'trades': Retrieves recent executions, trade size/price and flags
         'trade-breaks': Lists execution breaks for the current trading session
         'trading-status': Returns status and cause codes for securities
-     
+
     :return: Object
     """
     from pandas_datareader.iex.deep import Deep
@@ -212,7 +212,7 @@ def DataReader(name, data_source=None, start=None, end=None,
             requests.sessions.Session instance to be used
     access_key : (str, None)
         Optional parameter to specify an API key for certain data sources.
-    
+
     Examples
     ----------
 
@@ -225,14 +225,14 @@ def DataReader(name, data_source=None, start=None, end=None,
 
     # Data from Google Finance
     aapl = DataReader("AAPL", "google")
-    
+
     # Price and volume data from IEX
     tops = DataReader(["GS", "AAPL"], "iex-tops")
     # Top of book executions from IEX
     gs = DataReader("GS", "iex-last")
     # Real-time depth of book data from IEX
     gs = DataReader("GS", "iex-book")
-    
+
     # Data from FRED
     vix = DataReader("VIXCLS", "fred")
 

--- a/pandas_datareader/iex/__init__.py
+++ b/pandas_datareader/iex/__init__.py
@@ -4,8 +4,10 @@ from pandas.io.common import urlencode
 from pandas_datareader.base import _BaseReader
 
 # Data provided for free by IEX
-# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
-# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
 
 
 class IEX(_BaseReader):
@@ -19,9 +21,9 @@ class IEX(_BaseReader):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(IEX, self).__init__(symbols=symbols,
-                                      start=start, end=end,
-                                      retry_count=retry_count,
-                                      pause=pause, session=session)
+                                  start=start, end=end,
+                                  retry_count=retry_count,
+                                  pause=pause, session=session)
 
     @property
     def service(self):
@@ -31,7 +33,8 @@ class IEX(_BaseReader):
     @property
     def url(self):
         qstring = urlencode(self._get_params(self.symbols))
-        return "https://api.iextrading.com/1.0/{}?{}".format(self.service, qstring)
+        return "https://api.iextrading.com/1.0/{}?{}".format(self.service,
+                                                             qstring)
 
     def read(self):
         df = super(IEX, self).read()
@@ -46,8 +49,9 @@ class IEX(_BaseReader):
         return p
 
     def _output_error(self, out):
-        """If IEX returns a non-200 status code, we need to notify the user of the error returned.
-        
+        """If IEX returns a non-200 status code, we need to notify the user of
+        the error returned.
+
         :param out: Raw HTTP Output
         """
         try:
@@ -61,8 +65,9 @@ class IEX(_BaseReader):
                 raise Exception(e)
 
     def _read_lines(self, out):
-        """IEX's output does not need anything complex, so we're overriding to use Pandas' default interpreter
-        
+        """IEX's output does not need anything complex, so we're overriding to
+        use Pandas' default interpreter
+
         :param out: Raw HTTP Output
         :return: DataFrame
         """

--- a/pandas_datareader/iex/__init__.py
+++ b/pandas_datareader/iex/__init__.py
@@ -1,0 +1,73 @@
+import json
+import pandas as pd
+from pandas.io.common import urlencode
+from pandas_datareader.base import _BaseReader
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+
+
+class IEX(_BaseReader):
+
+    """
+    Serves as the base class for all IEX API services.
+    """
+
+    _format = 'json'
+
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(IEX, self).__init__(symbols=symbols,
+                                      start=start, end=end,
+                                      retry_count=retry_count,
+                                      pause=pause, session=session)
+
+    @property
+    def service(self):
+        # This property will be overridden by the subclass
+        raise NotImplementedError("IEX API service not specified.")
+
+    @property
+    def url(self):
+        qstring = urlencode(self._get_params(self.symbols))
+        return "https://api.iextrading.com/1.0/{}?{}".format(self.service, qstring)
+
+    def read(self):
+        df = super(IEX, self).read()
+        return df
+
+    def _get_params(self, symbols):
+        p = {}
+        if isinstance(symbols, list):
+            p['symbols'] = ','.join(symbols)
+        elif isinstance(symbols, str):
+            p['symbols'] = symbols
+        return p
+
+    def _output_error(self, out):
+        """If IEX returns a non-200 status code, we need to notify the user of the error returned.
+        
+        :param out: Raw HTTP Output
+        """
+        try:
+            content = json.loads(out.text)
+        except:
+            raise TypeError("Failed to interpret response as JSON.")
+
+        for key, string in content.items():
+            e = "IEX Output error encountered: {}".format(string)
+            if key == 'error':
+                raise Exception(e)
+
+    def _read_lines(self, out):
+        """IEX's output does not need anything complex, so we're overriding to use Pandas' default interpreter
+        
+        :param out: Raw HTTP Output
+        :return: DataFrame
+        """
+
+        # IEX will return a blank line for invalid tickers:
+        if isinstance(out, list):
+            out = [x for x in out if x is not None]
+        return pd.DataFrame(out) if len(out) > 0 else pd.DataFrame()

--- a/pandas_datareader/iex/deep.py
+++ b/pandas_datareader/iex/deep.py
@@ -1,0 +1,121 @@
+from pandas_datareader.iex import IEX
+from datetime import datetime
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
+
+
+class Deep(IEX):
+    def __init__(self, symbols=None, service=None, start=None, end=None,
+                 retry_count=3, pause=0.001, session=None):
+        super(Deep, self).__init__(symbols=symbols,
+                                   start=start, end=end,
+                                   retry_count=retry_count,
+                                   pause=pause, session=session)
+        self.sub = service
+
+    @property
+    def service(self):
+        ss = "/" + self.sub if self.sub is not None else ""
+        return "deep{}".format(ss)
+
+    def _read_lines(self, out):
+        """
+        IEX depth of book data varies and shouldn't always be returned in a DF
+
+        :param out: Raw HTTP Output
+        :return: DataFrame
+        """
+
+        # Runs appropriate output functions per the service being accessed.
+        fmap = {
+            'book': '_pass',
+            'op-halt-status': '_convert_tstamp',
+            'security-event': '_convert_tstamp',
+            'ssr-status': '_convert_tstamp',
+            'system-event': '_read_system_event',
+            'trades': '_pass',
+            'trade-breaks': '_convert_tstamp',
+            'trading-status': '_read_trading_status',
+            None: '_pass',
+        }
+
+        if self.sub in fmap:
+            return getattr(self, fmap[self.sub])(out)
+        else:
+            raise "Invalid service specified: {}.".format(self.sub)
+
+    def _read_system_event(self, out):
+        # Map the response code to a string output per the API docs.
+        # Per: https://www.iextrading.com/developer/docs/#system-event-message
+        smap = {
+            'O': 'Start of messages',
+            'S': 'Start of system hours',
+            'R': 'Start of regular market hours',
+            'M': 'End of regular market hours',
+            'E': 'End of system hours',
+            'C': 'End of messages'
+        }
+        tid = out["systemEvent"]
+        out["eventResponse"] = smap[tid]
+
+        return self._convert_tstamp(out)
+
+    @staticmethod
+    def _pass(out):
+        return out
+
+    def _read_trading_status(self, out):
+        # Reference: https://www.iextrading.com/developer/docs/#trading-status
+        smap = {
+            'H': 'Trading halted across all US equity markets',
+            'O': 'Trading halt released into an Order Acceptance Period '
+                 '(IEX-listed securities only)',
+            'P': 'Trading paused and Order Acceptance Period on IEX '
+                 '(IEX-listed securities only)',
+            'T': 'Trading on IEX'
+        }
+        rmap = {
+            # Trading Halt Reasons
+            'T1': 'Halt News Pending',
+            'IPO1': 'IPO/New Issue Not Yet Trading',
+            'IPOD': 'IPO/New Issue Deferred',
+            'MCB3': 'Market-Wide Circuit Breaker Level 3 - Breached',
+            'NA': 'Reason Not Available',
+
+            # Order Acceptance Period Reasons
+            'T2': 'Halt News Dissemination',
+            'IPO2': 'IPO/New Issue Order Acceptance Period',
+            'IPO3': 'IPO Pre-Launch Period',
+            'MCB1': 'Market-Wide Circuit Breaker Level 1 - Breached',
+            'MCB2': 'Market-Wide Circuit Breaker Level 2 - Breached'
+        }
+        for ticker, data in out.items():
+            if data['status'] in smap:
+                data['statusText'] = smap[data['status']]
+
+            if data['reason'] in rmap:
+                data['reasonText'] = rmap[data['reason']]
+
+            out[ticker] = data
+
+        return self._convert_tstamp(out)
+
+    @staticmethod
+    def _convert_tstamp(out):
+        # Searches for top-level timestamp attributes or within dictionaries
+        if 'timestamp' in out:
+            # Convert UNIX to datetime object
+            f = float(out["timestamp"])
+            out["timestamp"] = datetime.fromtimestamp(f/1000)
+        else:
+            for ticker, data in out.items():
+                if 'timestamp' in data:
+                    f = float(data["timestamp"])
+                    data["timestamp"] = datetime.fromtimestamp(f/1000)
+                    out[ticker] = data
+
+        return out

--- a/pandas_datareader/iex/market.py
+++ b/pandas_datareader/iex/market.py
@@ -1,0 +1,22 @@
+from pandas_datareader.iex import IEX
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+
+
+class MarketReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(MarketReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "market"
+
+    def _get_params(self, symbols):
+        # Market API does not take any parameters, returning empty dict
+        return {}

--- a/pandas_datareader/iex/market.py
+++ b/pandas_datareader/iex/market.py
@@ -1,17 +1,19 @@
 from pandas_datareader.iex import IEX
 
 # Data provided for free by IEX
-# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
-# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
 
 
 class MarketReader(IEX):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(MarketReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                           start=start, end=end,
+                                           retry_count=retry_count,
+                                           pause=pause, session=session)
 
     @property
     def service(self):

--- a/pandas_datareader/iex/ref.py
+++ b/pandas_datareader/iex/ref.py
@@ -1,0 +1,22 @@
+from pandas_datareader.iex import IEX
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+
+
+class SymbolsReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(SymbolsReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "ref-data/symbols"
+
+    def _get_params(self, symbols):
+        # Ref Data API does not take any parameters, returning empty dict
+        return {}

--- a/pandas_datareader/iex/ref.py
+++ b/pandas_datareader/iex/ref.py
@@ -1,17 +1,19 @@
 from pandas_datareader.iex import IEX
 
 # Data provided for free by IEX
-# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
-# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
 
 
 class SymbolsReader(IEX):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(SymbolsReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                            start=start, end=end,
+                                            retry_count=retry_count,
+                                            pause=pause, session=session)
 
     @property
     def service(self):

--- a/pandas_datareader/iex/stats.py
+++ b/pandas_datareader/iex/stats.py
@@ -3,8 +3,10 @@ from datetime import datetime, timedelta
 from pandas_datareader.iex import IEX
 
 # Data provided for free by IEX
-# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
-# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
 
 
 class DailySummaryReader(IEX):
@@ -12,9 +14,9 @@ class DailySummaryReader(IEX):
                  pause=0.001, session=None):
         self.curr_date = start
         super(DailySummaryReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                                 start=start, end=end,
+                                                 retry_count=retry_count,
+                                                 pause=pause, session=session)
 
     @property
     def service(self):
@@ -29,9 +31,10 @@ class DailySummaryReader(IEX):
         return p
 
     def read(self):
-        """Unfortunately, IEX's API can only retrieve data one day or one month at a time. Rather than specifying a date
-        range, we will have to run the read function for each date provided.
-        
+        """Unfortunately, IEX's API can only retrieve data one day or one month
+        at a time. Rather than specifying a date range, we will have to run
+        the read function for each date provided.
+
         :return: DataFrame
         """
         tlen = self.end - self.start
@@ -50,9 +53,10 @@ class MonthlySummaryReader(IEX):
         self.date_format = '%Y%m'
 
         super(MonthlySummaryReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                                   start=start, end=end,
+                                                   retry_count=retry_count,
+                                                   pause=pause,
+                                                   session=session)
 
     @property
     def service(self):
@@ -67,16 +71,18 @@ class MonthlySummaryReader(IEX):
         return p
 
     def read(self):
-        """Unfortunately, IEX's API can only retrieve data one day or one month at a time. Rather than specifying a date
-        range, we will have to run the read function for each date provided.
-        
+        """Unfortunately, IEX's API can only retrieve data one day or one month
+         at a time. Rather than specifying a date range, we will have to run
+         the read function for each date provided.
+
         :return: DataFrame
         """
         tlen = self.end - self.start
         dfs = []
 
         # Build list of all dates within the given range
-        lrange = [x for x in (self.start + timedelta(n) for n in range(tlen.days))]
+        lrange = [x for x in (self.start + timedelta(n)
+                              for n in range(tlen.days))]
 
         mrange = []
         for dt in lrange:
@@ -101,9 +107,9 @@ class RecordsReader(IEX):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(RecordsReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                            start=start, end=end,
+                                            retry_count=retry_count,
+                                            pause=pause, session=session)
 
     @property
     def service(self):
@@ -118,9 +124,9 @@ class RecentReader(IEX):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(RecentReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                           start=start, end=end,
+                                           retry_count=retry_count,
+                                           pause=pause, session=session)
 
     @property
     def service(self):

--- a/pandas_datareader/iex/stats.py
+++ b/pandas_datareader/iex/stats.py
@@ -1,0 +1,131 @@
+import pandas as pd
+from datetime import datetime, timedelta
+from pandas_datareader.iex import IEX
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+
+
+class DailySummaryReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        self.curr_date = start
+        super(DailySummaryReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "stats/historical/daily"
+
+    def _get_params(self, symbols):
+        p = {}
+
+        if self.curr_date is not None:
+            p['date'] = self.curr_date.strftime('%Y%m%d')
+
+        return p
+
+    def read(self):
+        """Unfortunately, IEX's API can only retrieve data one day or one month at a time. Rather than specifying a date
+        range, we will have to run the read function for each date provided.
+        
+        :return: DataFrame
+        """
+        tlen = self.end - self.start
+        dfs = []
+        for date in (self.start + timedelta(n) for n in range(tlen.days)):
+            self.curr_date = date
+            tdf = super(IEX, self).read()
+            dfs.append(tdf)
+        return pd.concat(dfs)
+
+
+class MonthlySummaryReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        self.curr_date = start
+        self.date_format = '%Y%m'
+
+        super(MonthlySummaryReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "stats/historical"
+
+    def _get_params(self, symbols):
+        p = {}
+
+        if self.curr_date is not None:
+            p['date'] = self.curr_date.strftime(self.date_format)
+
+        return p
+
+    def read(self):
+        """Unfortunately, IEX's API can only retrieve data one day or one month at a time. Rather than specifying a date
+        range, we will have to run the read function for each date provided.
+        
+        :return: DataFrame
+        """
+        tlen = self.end - self.start
+        dfs = []
+
+        # Build list of all dates within the given range
+        lrange = [x for x in (self.start + timedelta(n) for n in range(tlen.days))]
+
+        mrange = []
+        for dt in lrange:
+            if datetime(dt.year, dt.month, 1) not in mrange:
+                mrange.append(datetime(dt.year, dt.month, 1))
+        lrange = mrange
+
+        for date in lrange:
+            self.curr_date = date
+            tdf = super(IEX, self).read()
+
+            # We may not return data if this was a weekend/holiday:
+            if not tdf.empty:
+                tdf['date'] = date.strftime(self.date_format)
+                dfs.append(tdf)
+
+        # We may not return any data if we failed to specify useful parameters:
+        return pd.concat(dfs) if len(dfs) > 0 else pd.DataFrame()
+
+
+class RecordsReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(RecordsReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "stats/records"
+
+    def _get_params(self, symbols):
+        # Record Stats API does not take any parameters, returning empty dict
+        return {}
+
+
+class RecentReader(IEX):
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(RecentReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "stats/recent"
+
+    def _get_params(self, symbols):
+        # Record Stats API does not take any parameters, returning empty dict
+        return {}

--- a/pandas_datareader/iex/tops.py
+++ b/pandas_datareader/iex/tops.py
@@ -1,8 +1,10 @@
 from pandas_datareader.iex import IEX
 
 # Data provided for free by IEX
-# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
-# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+# Data is furnished in compliance with the guidelines promulgated in the IEX
+# API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information
+# and conditions of use
 
 
 class TopsReader(IEX):
@@ -10,9 +12,9 @@ class TopsReader(IEX):
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(TopsReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                         start=start, end=end,
+                                         retry_count=retry_count,
+                                         pause=pause, session=session)
 
     @property
     def service(self):
@@ -20,13 +22,13 @@ class TopsReader(IEX):
 
 
 class LastReader(IEX):
-    # todo: Eventually we'll want to implement the WebSockets version as an option.
+    # todo: Eventually we'll want to implement WebSockets as an option.
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None):
         super(LastReader, self).__init__(symbols=symbols,
-                                          start=start, end=end,
-                                          retry_count=retry_count,
-                                          pause=pause, session=session)
+                                         start=start, end=end,
+                                         retry_count=retry_count,
+                                         pause=pause, session=session)
 
     @property
     def service(self):

--- a/pandas_datareader/iex/tops.py
+++ b/pandas_datareader/iex/tops.py
@@ -1,0 +1,33 @@
+from pandas_datareader.iex import IEX
+
+# Data provided for free by IEX
+# Data is furnished in compliance with the guidelines promulgated in the IEX API terms of service and manual
+# See https://iextrading.com/api-exhibit-a/ for additional information and conditions of use
+
+
+class TopsReader(IEX):
+
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(TopsReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "tops"
+
+
+class LastReader(IEX):
+    # todo: Eventually we'll want to implement the WebSockets version as an option.
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None):
+        super(LastReader, self).__init__(symbols=symbols,
+                                          start=start, end=end,
+                                          retry_count=retry_count,
+                                          pause=pause, session=session)
+
+    @property
+    def service(self):
+        return "tops/last"

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -32,6 +32,10 @@ class TestDataReader(object):
         gs = DataReader("GS", "google")
         assert isinstance(gs, DataFrame)
 
+    def test_read_iex(self):
+        gs = DataReader("GS", "iex-last")
+        assert isinstance(gs, DataFrame)
+
     def test_read_fred(self):
         vix = DataReader("VIXCLS", "fred")
         assert isinstance(vix, DataFrame)

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -39,3 +39,9 @@ class TestIEX(object):
         tickers = dftickers[:5].symbol.values
         df = get_last_iex(tickers[:5])
         assert df["price"].mean() > 0
+
+    def test_deep(self):
+        dob = DataReader('GS', 'iex-book')
+        assert 'GS' in dob
+        assert 'asks' in dob['GS']
+        assert dob['GS']['bids'][0]['price'] > 0

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -3,9 +3,10 @@ import pytest
 import pandas.util.testing as tm
 
 from pandas import DataFrame
-from datetime import datetime
+from datetime import datetime, timedelta
 from pandas_datareader.data import (DataReader, get_summary_iex, get_last_iex,
-                                    get_data_iex, get_iex_symbols)
+                                    get_dailysummary_iex, get_iex_symbols,
+                                    get_iex_book)
 
 
 class TestIEX(object):
@@ -27,7 +28,7 @@ class TestIEX(object):
         tm.assert_frame_equal(df, DataFrame())
 
     def test_daily(self):
-        df = get_data_iex(start=datetime(2017, 5, 5), end=datetime(2017, 5, 6))
+        df = get_dailysummary_iex(start=datetime(2017, 5, 5), end=datetime(2017, 5, 6))  #noqa
         assert df['routedVolume'].iloc[0] == 39974788
 
     def test_symbols(self):
@@ -41,7 +42,6 @@ class TestIEX(object):
         assert df["price"].mean() > 0
 
     def test_deep(self):
-        dob = DataReader('GS', 'iex-book')
-        assert 'GS' in dob
-        assert 'asks' in dob['GS']
-        assert dob['GS']['bids'][0]['price'] > 0
+        dob = get_iex_book('GS', service='system-event')
+        assert len(dob['eventResponse']) > 0
+        assert dob['timestamp'] > datetime.now() - timedelta(days=1)

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -1,47 +1,41 @@
-from datetime import datetime
-from pandas import DataFrame
-from pandas_datareader.data import *
+import pytest
 
-import nose
 import pandas.util.testing as tm
-from pandas.util.testing import (assert_series_equal, assert_frame_equal)
+
+from pandas import DataFrame
+from datetime import datetime
+from pandas_datareader.data import (DataReader, get_summary_iex, get_last_iex,
+                                    get_data_iex, get_iex_symbols)
 
 
-class TestIEX(tm.TestCase):
+class TestIEX(object):
     @classmethod
-    def setUpClass(cls):
-        super(TestIEX, cls).setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestIEX, cls).tearDownClass()
+    def setup_class(cls):
+        pytest.importorskip("lxml")
 
     def test_read_iex(self):
         gs = DataReader("GS", "iex-last")
         assert isinstance(gs, DataFrame)
 
     def test_historical(self):
-        df = get_summary_iex(start=datetime(2017, 4, 1), end=datetime(2017, 4, 30))
-        self.assertEqual(df["averageDailyVolume"].iloc[0], 137650908.9)
+        df = get_summary_iex(start=datetime(2017, 4, 1),
+                             end=datetime(2017, 4, 30))
+        assert df["averageDailyVolume"].iloc[0] == 137650908.9
 
     def test_false_ticker(self):
         df = get_last_iex("INVALID TICKER")
-        assert_frame_equal(df, DataFrame())
+        tm.assert_frame_equal(df, DataFrame())
 
     def test_daily(self):
         df = get_data_iex(start=datetime(2017, 5, 5), end=datetime(2017, 5, 6))
-        self.assertEqual(df['routedVolume'].iloc[0], 39974788)
+        assert df['routedVolume'].iloc[0] == 39974788
 
     def test_symbols(self):
         df = get_iex_symbols()
-        self.assertTrue('GS' in df.symbol.values)
+        assert 'GS' in df.symbol.values
 
     def test_live_prices(self):
         dftickers = get_iex_symbols()
         tickers = dftickers[:5].symbol.values
         df = get_last_iex(tickers[:5])
-        self.assertGreater(df["price"].mean(), 0)
-
-if __name__ == '__main__':
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)  # pragma: no cover
+        assert df["price"].mean() > 0

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from pandas import DataFrame
+from pandas_datareader.data import *
+
+import nose
+import pandas.util.testing as tm
+from pandas.util.testing import (assert_series_equal, assert_frame_equal)
+
+
+class TestIEX(tm.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestIEX, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestIEX, cls).tearDownClass()
+
+    def test_read_iex(self):
+        gs = DataReader("GS", "iex-last")
+        assert isinstance(gs, DataFrame)
+
+    def test_historical(self):
+        df = get_summary_iex(start=datetime(2017, 4, 1), end=datetime(2017, 4, 30))
+        self.assertEqual(df["averageDailyVolume"].iloc[0], 137650908.9)
+
+    def test_false_ticker(self):
+        df = get_last_iex("INVALID TICKER")
+        assert_frame_equal(df, DataFrame())
+
+    def test_daily(self):
+        df = get_data_iex(start=datetime(2017, 5, 5), end=datetime(2017, 5, 6))
+        self.assertEqual(df['routedVolume'].iloc[0], 39974788)
+
+    def test_symbols(self):
+        df = get_iex_symbols()
+        self.assertTrue('GS' in df.symbol.values)
+
+    def test_live_prices(self):
+        dftickers = get_iex_symbols()
+        tickers = dftickers[:5].symbol.values
+        df = get_last_iex(tickers[:5])
+        self.assertGreater(df["price"].mean(), 0)
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)  # pragma: no cover

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -28,7 +28,8 @@ class TestIEX(object):
         tm.assert_frame_equal(df, DataFrame())
 
     def test_daily(self):
-        df = get_dailysummary_iex(start=datetime(2017, 5, 5), end=datetime(2017, 5, 6))  #noqa
+        df = get_dailysummary_iex(start=datetime(2017, 5, 5),
+                                  end=datetime(2017, 5, 6))
         assert df['routedVolume'].iloc[0] == 39974788
 
     def test_symbols(self):


### PR DESCRIPTION
IEX recently announced the first version of [a free market data API](https://www.iextrading.com/developer/) used to access a wide variety of data useful for traders, consisting of:

- Highest volume stocks in the most recent trading session ([Tops API;](https://www.iextrading.com/developer/#tops-tops) allows for subset selection)
- Live prices ([Last API](https://www.iextrading.com/developer/#tops-last), also available in websockets)
- Trade volume by venue for the most recent trading session ([Market API](https://www.iextrading.com/developer/#market); separately reported by tape)
-  Market Records, by trade volume, symbol volume, route volume and notional value ([Stats API](https://www.iextrading.com/developer/#stats-records))
- Monthly and Daily historical summaries of trade volume ([Stats API](https://www.iextrading.com/developer/#stats-historical); separately reported by venue, symbol market cap, and order size)
- Eligible symbols on IEX's platform (via [Ref Data API](https://www.iextrading.com/developer/#ref-data))

 This pull request implements all of the services available in their initial launch, except for the live prices via socket, and makes them available in DataFrames via pandas_datareader. Note that the API will return None for weekends and market holidays, and reports a special field for half days. Some examples:

```
import pandas_datareader as pdr

# Retrieve highest volume stocks for the previous session
tops = pdr.DataReader(source="iex-tops")

# Get most recent price (live)
px = pdr.get_last_iex("AAPL")
px = pdr.get_last_iex(["GOOG", "IBM"])

# Retrieve list of stocks that trade on IEX:
symbols = pdr.get_iex_symbols()

# Retrieve daily historical market volume info
ts = pdr.get_data_iex(start=datetime(2017, 1, 1), end=datetime(2017, 3, 31))
```

In the coming months, IEX also plans to implement:

- Depth of book (i.e. live level II quotes)
- Company info
- Company financial data
- Historical prices