### PR TITLE
TST: Add pandas wheels to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,38 @@ sudo: false
 
 language: python
 
-env:
-  - PYTHON=2.7 PANDAS=0.16.2
-  - PYTHON=2.7 PANDAS=0.17.1
-  - PYTHON=2.7 PANDAS=0.19.2
-  - PYTHON=3.4 PANDAS=0.17.1
-  - PYTHON=3.4 PANDAS=0.18.1
-  - PYTHON=3.5 PANDAS=0.19.2
-  - PYTHON=3.6 PANDAS=0.19.2
+matrix:
+  fast_finish: true
+  include:
+  - os: linux
+    env:
+      - PYTHON=2.7 PANDAS=0.17.1
+  - os: linux
+    env:
+      - PYTHON=2.7 PANDAS=0.19.2
+  - os: linux
+    env:
+      - PYTHON=3.5 PANDAS=0.17.1
+  - os: linux
+    env:
+      - PYTHON=3.5 PANDAS=0.18.1
+  - os: linux
+    env:
+      - PYTHON=3.5 PANDAS=0.19.2
+  - os: linux
+    env:
+      - PYTHON=3.6 PANDAS=0.19.2
+  - os: linux
+    env:
+      - PYTHON=3.6 PANDAS=0.20.1
+  # In allow failures
+  - os: linux
+    env:
+      - PYTHON=3.6 PANDAS="MASTER"
+  allow_failures:
+    - os: linux
+      env:
+        - PYTHON=3.6 PANDAS="MASTER"
 
 install:
   - pip install -qq flake8
@@ -30,8 +54,15 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$PYTHON pandas=$PANDAS coverage setuptools html5lib lxml pytest pytest-cov
+  - conda create -q -n test-environment python=$PYTHON coverage setuptools html5lib lxml pytest pytest-cov
   - source activate test-environment
+  - if [[ "$PANDAS" == "MASTER" ]]; then
+      conda install numpy pytz python-dateutil;
+      PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com";
+      pip install --pre --upgrade --timeout=60 -f $PRE_WHEELS pandas;
+    else
+      conda install pandas=$PANDAS;
+    fi
   - pip install beautifulsoup4
   - pip install coveralls --quiet
   - conda list

--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -8,8 +8,6 @@ from distutils.version import LooseVersion
 PANDAS_VERSION = LooseVersion(pd.__version__)
 
 PANDAS_0190 = (PANDAS_VERSION >= LooseVersion('0.19.0'))
-PANDAS_0170 = (PANDAS_VERSION >= LooseVersion('0.17.0'))
-PANDAS_0160 = (PANDAS_VERSION >= LooseVersion('0.16.0'))
 
 if PANDAS_0190:
     from pandas.api.types import is_number

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -1,11 +1,7 @@
-import pytest
-
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
-
-from pandas_datareader.compat import PANDAS_0170
 
 
 class TestEurostat(tm.TestCase):
@@ -66,9 +62,6 @@ class TestEurostat(tm.TestCase):
 
     def test_get_nrg_pc_202(self):
         # see gh-149
-
-        if not PANDAS_0170:
-            pytest.skip("skip because of comparison failure")
 
         df = web.DataReader('nrg_pc_202', 'eurostat',
                             start=pd.Timestamp('2010-01-01'),

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -8,7 +8,6 @@ import requests
 
 from pandas_datareader.wb import (search, download, get_countries,
                                   get_indicators, WorldBankReader)
-from pandas_datareader.compat import PANDAS_0170, PANDAS_0160
 
 
 class TestWB(tm.TestCase):
@@ -56,17 +55,12 @@ class TestWB(tm.TestCase):
         expected = pd.DataFrame(expected)
         # Round, to ignore revisions to data.
         expected = np.round(expected, decimals=-3)
-        if PANDAS_0170:
-            expected = expected.sort_index()
-        else:
-            expected = expected.sort()
+        expected = expected.sort_index()
 
         result = download(country=cntry_codes, indicator=inds,
                           start=2003, end=2004, errors='ignore')
-        if PANDAS_0170:
-            result = result.sort_index()
-        else:
-            result = result.sort()
+        result = result.sort_index()
+
         # Round, to ignore revisions to data.
         result = np.round(result, decimals=-3)
 
@@ -76,10 +70,8 @@ class TestWB(tm.TestCase):
         # pass start and end as string
         result = download(country=cntry_codes, indicator=inds,
                           start='2003', end='2004', errors='ignore')
-        if PANDAS_0170:
-            result = result.sort_index()
-        else:
-            result = result.sort()
+        result = result.sort_index()
+
         # Round, to ignore revisions to data.
         result = np.round(result, decimals=-3)
         tm.assert_frame_equal(result, expected)
@@ -94,19 +86,13 @@ class TestWB(tm.TestCase):
         expected = pd.DataFrame(expected)
         # Round, to ignore revisions to data.
         expected = np.round(expected, decimals=-3)
-        if PANDAS_0170:
-            expected = expected.sort_index()
-        else:
-            expected = expected.sort()
+        expected = expected.sort_index()
 
         cntry_codes = 'JP'
         inds = 'NY.GDP.PCAP.CD'
         result = download(country=cntry_codes, indicator=inds,
                           start=2000, end=2004, errors='ignore')
-        if PANDAS_0170:
-            result = result.sort_index()
-        else:
-            result = result.sort()
+        result = result.sort_index()
         result = np.round(result, decimals=-3)
 
         expected.index.names = ['country', 'year']
@@ -114,10 +100,7 @@ class TestWB(tm.TestCase):
 
         result = WorldBankReader(inds, countries=cntry_codes,
                                  start=2000, end=2004, errors='ignore').read()
-        if PANDAS_0170:
-            result = result.sort_index()
-        else:
-            result = result.sort()
+        result = result.sort_index()
         result = np.round(result, decimals=-3)
         tm.assert_frame_equal(result, expected)
 
@@ -126,30 +109,28 @@ class TestWB(tm.TestCase):
         inds = 'NY.GDP.PCAP.CD'
 
         with tm.assertRaisesRegexp(ValueError, "Invalid Country Code\\(s\\): XX"):
-            result = download(country=cntry_codes, indicator=inds,
-                              start=2003, end=2004, errors='raise')
+            download(country=cntry_codes, indicator=inds,
+                     start=2003, end=2004, errors='raise')
 
-        if PANDAS_0160:
-            # assert_produces_warning doesn't exists in prior versions
-            with self.assert_produces_warning():
-                result = download(country=cntry_codes, indicator=inds,
-                                  start=2003, end=2004, errors='warn')
-                self.assertTrue(isinstance(result, pd.DataFrame))
-                self.assertEqual(len(result), 2)
+        # assert_produces_warning doesn't exists in prior versions
+        with self.assert_produces_warning():
+            result = download(country=cntry_codes, indicator=inds,
+                              start=2003, end=2004, errors='warn')
+            self.assertTrue(isinstance(result, pd.DataFrame))
+            self.assertEqual(len(result), 2)
 
         cntry_codes = ['USA']
         inds = ['NY.GDP.PCAP.CD', 'BAD_INDICATOR']
 
         with tm.assertRaisesRegexp(ValueError, "The provided parameter value is not valid\\. Indicator: BAD_INDICATOR"):
-            result = download(country=cntry_codes, indicator=inds,
-                              start=2003, end=2004, errors='raise')
+            download(country=cntry_codes, indicator=inds,
+                     start=2003, end=2004, errors='raise')
 
-        if PANDAS_0160:
-            with self.assert_produces_warning():
-                result = download(country=cntry_codes, indicator=inds,
-                                  start=2003, end=2004, errors='warn')
-                self.assertTrue(isinstance(result, pd.DataFrame))
-                self.assertEqual(len(result), 2)
+        with self.assert_produces_warning():
+            result = download(country=cntry_codes, indicator=inds,
+                              start=2003, end=2004, errors='warn')
+            self.assertTrue(isinstance(result, pd.DataFrame))
+            self.assertEqual(len(result), 2)
 
     def test_wdi_download_w_retired_indicator(self):
 

--- a/pandas_datareader/wb.py
+++ b/pandas_datareader/wb.py
@@ -7,7 +7,6 @@ import pandas as pd
 import numpy as np
 
 from pandas_datareader.base import _BaseReader
-from pandas_datareader.compat import PANDAS_0170
 
 # This list of country codes was pulled from wikipedia during October 2014.
 # While some exceptions do exist, it is the best proxy for countries supported
@@ -178,11 +177,8 @@ class WorldBankReader(_BaseReader):
             out = reduce(lambda x, y: x.merge(y, how='outer'), data)
             out = out.drop('iso_code', axis=1)
             out = out.set_index(['country', 'year'])
-            if PANDAS_0170:
-                out = out.apply(pd.to_numeric, errors='ignore')
-            else:
-                # deprecated in 0.17.0
-                out = out.convert_objects(convert_numeric=True)
+            out = out.apply(pd.to_numeric, errors='ignore')
+
             return out
         else:
             msg = "No indicators returned data."
@@ -275,11 +271,9 @@ class WorldBankReader(_BaseReader):
 
         data.topics = data.topics.apply(get_list_of_values)
         data.topics = data.topics.apply(lambda x: ' ; '.join(x))
-        # Clean outpu
-        if PANDAS_0170:
-            data = data.sort_values(by='id')
-        else:
-            data = data.sort(columns='id')
+
+        # Clean output
+        data = data.sort_values(by='id')
         data.index = pd.Index(lrange(data.shape[0]))
 
         # cache


### PR DESCRIPTION
* Add pandas `0.20.1` and `master` to Travis.
* Drop `0.16.2` and Python 3.4 machines.

Closes #307.