### PR TITLE
TST: Remove self.assert* from testing

### DIFF
--- a/pandas_datareader/io/tests/test_jsdmx.py
+++ b/pandas_datareader/io/tests/test_jsdmx.py
@@ -16,52 +16,58 @@ class TestJSDMX(tm.TestCase):
 
     def test_tourism(self):
         # OECD -> Industry and Services -> Inbound Tourism
-        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx', 'tourism.json'))
-        self.assertTrue(isinstance(result, pd.DataFrame))
+        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx',
+                                         'tourism.json'))
+        assert isinstance(result, pd.DataFrame)
 
-        exp_col = pd.MultiIndex.from_product([['Japan'],
-                                              ['China', 'Hong Kong, China',
-                                               'Total international arrivals',
-                                               'Total international receipts',
-                                               'International passenger transport receipts',
-                                               'International travel receipts',
-                                               'Korea', 'Chinese Taipei', 'United States']],
-                                             names=['Country', 'Variable'])
-        exp_idx = pd.DatetimeIndex(['2004', '2005', '2006', '2007', '2008',
-                                    '2009', '2010', '2011', '2012'], name='Year')
+        exp_col = pd.MultiIndex.from_product(
+            [['Japan'], ['China', 'Hong Kong, China',
+                         'Total international arrivals',
+                         'Total international receipts',
+                         'International passenger transport receipts',
+                         'International travel receipts',
+                         'Korea', 'Chinese Taipei', 'United States']],
+            names=['Country', 'Variable'])
+        exp_idx = pd.DatetimeIndex(['2004', '2005', '2006', '2007',
+                                    '2008', '2009', '2010', '2011',
+                                    '2012'], name='Year')
 
-        values = np.array([[616, 300, 6138, 1550, 330, 1220, 1588, 1081, 760],
-                           [653, 299, 6728, 1710, 340, 1370, 1747, 1275, 822],
-                           [812, 352, 7334, 1330, 350, 980, 2117, 1309, 817],
-                           [942, 432, 8347, 1460, 360, 1100, 2601, 1385, 816],
-                           [1000, 550, 8351, 1430, 310, 1120, 2382, 1390, 768],
-                           [1006, 450, 6790, 1170, 210, 960, 1587, 1024, 700],
-                           [1413, 509, 8611, 1350, 190, 1160, 2440, 1268, 727],
-                           [1043, 365, 6219, 1000, 100, 900, 1658, 994, 566],
-                           [1430, 482, 8368, 1300, 100, 1200, 2044, 1467, 717]])
+        values = np.array([
+            [616, 300, 6138, 1550, 330, 1220, 1588, 1081, 760],
+            [653, 299, 6728, 1710, 340, 1370, 1747, 1275, 822],
+            [812, 352, 7334, 1330, 350, 980, 2117, 1309, 817],
+            [942, 432, 8347, 1460, 360, 1100, 2601, 1385, 816],
+            [1000, 550, 8351, 1430, 310, 1120, 2382, 1390, 768],
+            [1006, 450, 6790, 1170, 210, 960, 1587, 1024, 700],
+            [1413, 509, 8611, 1350, 190, 1160, 2440, 1268, 727],
+            [1043, 365, 6219, 1000, 100, 900, 1658, 994, 566],
+            [1430, 482, 8368, 1300, 100, 1200, 2044, 1467, 717]])
         expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
         tm.assert_frame_equal(result, expected)
 
     def test_land_use(self):
         # OECD -> Environment -> Resources Land Use
-        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx', 'land_use.json'))
-        self.assertTrue(isinstance(result, pd.DataFrame))
+        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx',
+                                         'land_use.json'))
+        assert isinstance(result, pd.DataFrame)
         result = result.ix['2010':'2011']
 
-        exp_col = pd.MultiIndex.from_product([['Japan', 'United States'],
-                                              ['Arable land and permanent crops',
-                                               'Arable and cropland % land area',
-                                               'Total area', 'Forest', 'Forest % land area',
-                                               'Land area', 'Permanent meadows and pastures',
-                                               'Meadows and pastures % land area',
-                                               'Other areas', 'Other % land area']],
-                                             names=['Country', 'Variable'])
+        exp_col = pd.MultiIndex.from_product([
+            ['Japan', 'United States'],
+            ['Arable land and permanent crops',
+             'Arable and cropland % land area',
+             'Total area', 'Forest', 'Forest % land area',
+             'Land area', 'Permanent meadows and pastures',
+             'Meadows and pastures % land area', 'Other areas',
+             'Other % land area']], names=['Country', 'Variable'])
         exp_idx = pd.DatetimeIndex(['2010', '2011'], name='Year')
-        values = np.array([[45930, 12.601, 377950, 249790, 68.529, 364500, np.nan, np.nan,
-                            68780, 18.87, 1624330, 17.757, 9831510, 3040220, 33.236, 9147420,
-                            2485000, 27.166, 1997870, 21.841],
-                           [45610, 12.513, 377955, 249878, 68.554, 364500, np.nan, np.nan,
-                            69012, 18.933, 1627625, 17.793, 9831510, 3044048, 33.278, 9147420,
-                            2485000, 27.166, 1990747, 21.763]])
+        values = np.array([[45930, 12.601, 377950, 249790, 68.529, 364500,
+                            np.nan, np.nan, 68780, 18.87, 1624330, 17.757,
+                            9831510, 3040220, 33.236, 9147420, 2485000,
+                            27.166, 1997870, 21.841],
+                           [45610, 12.513, 377955, 249878, 68.554, 364500,
+                            np.nan, np.nan, 69012, 18.933, 1627625, 17.793,
+                            9831510, 3044048, 33.278, 9147420, 2485000,
+                            27.166, 1990747, 21.763]])
         expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
         tm.assert_frame_equal(result, expected)

--- a/pandas_datareader/io/tests/test_sdmx.py
+++ b/pandas_datareader/io/tests/test_sdmx.py
@@ -18,17 +18,19 @@ class TestSDMX(tm.TestCase):
         # Eurostat
         # Employed doctorate holders in non managerial and non professional
         # occupations by fields of science (%)
-        dsd = _read_sdmx_dsd(os.path.join(self.dirpath, 'sdmx', 'DSD_cdh_e_fos.xml'))
-        df = read_sdmx(os.path.join(self.dirpath, 'sdmx', 'cdh_e_fos.xml'), dsd=dsd)
+        dsd = _read_sdmx_dsd(os.path.join(self.dirpath, 'sdmx',
+                                          'DSD_cdh_e_fos.xml'))
+        df = read_sdmx(os.path.join(self.dirpath, 'sdmx',
+                                    'cdh_e_fos.xml'), dsd=dsd)
 
-        self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertEqual(df.shape, (2, 336))
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (2, 336)
 
         df = df['Percentage']['Total']['Natural sciences']
         df = df[['Norway', 'Poland', 'Portugal', 'Russia']]
 
-        exp_col = pd.MultiIndex.from_product([['Norway', 'Poland', 'Portugal', 'Russia'],
-                                              ['Annual']],
+        exp_col = pd.MultiIndex.from_product([['Norway', 'Poland', 'Portugal',
+                                               'Russia'], ['Annual']],
                                              names=['GEO', 'FREQ'])
         exp_idx = pd.DatetimeIndex(['2009', '2006'], name='TIME_PERIOD')
 

--- a/pandas_datareader/tests/test_base.py
+++ b/pandas_datareader/tests/test_base.py
@@ -1,20 +1,21 @@
+import pytest
 import pandas.util.testing as tm
 import pandas_datareader.base as base
 
 
 class TestBaseReader(tm.TestCase):
     def test_valid_retry_count(self):
-        with tm.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             base._BaseReader([], retry_count='stuff')
-        with tm.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             base._BaseReader([], retry_count=-1)
 
     def test_invalid_url(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             base._BaseReader([]).url
 
     def test_invalid_format(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             b = base._BaseReader([])
             b._format = 'IM_NOT_AN_IMPLEMENTED_TYPE'
             b._read_one_data('a', None)
@@ -22,6 +23,6 @@ class TestBaseReader(tm.TestCase):
 
 class TestDailyBaseReader(tm.TestCase):
     def test_get_params(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             b = base._DailyBaseReader()
             b._get_params()

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pandas.util.testing as tm
 import pandas_datareader.data as web
 
@@ -20,10 +22,6 @@ class TestOptionsWarnings(tm.TestCase):
 
 
 class TestDataReader(tm.TestCase):
-    def test_is_s3_url(self):
-        from pandas.io.common import _is_s3_url
-        self.assertTrue(_is_s3_url("s3://pandas/somethingelse.com"))
-
     def test_read_yahoo(self):
         gs = DataReader("GS", "yahoo")
         assert isinstance(gs, DataFrame)
@@ -41,4 +39,5 @@ class TestDataReader(tm.TestCase):
         assert isinstance(vix, DataFrame)
 
     def test_not_implemented(self):
-        self.assertRaises(NotImplementedError, DataReader, "NA", "NA")
+        with pytest.raises(NotImplementedError):
+            DataReader("NA", "NA")

--- a/pandas_datareader/tests/test_edgar.py
+++ b/pandas_datareader/tests/test_edgar.py
@@ -32,10 +32,10 @@ class TestEdgarIndex(tm.TestCase):
             ed = web.DataReader('daily', 'edgar-index', '1994-06-30',
                                 '1994-07-02')
             assert len(ed) > 200
+            assert ed.index.nlevels == 2
 
-            self.assertEqual(ed.index.nlevels, 2)
             dti = ed.index.get_level_values(0)
-            self.assertIsInstance(dti, pd.DatetimeIndex)
+            assert isinstance(dti, pd.DatetimeIndex)
             exp_columns = pd.Index(['company_name', 'form_type',
                                     'filename'], dtype='object')
             tm.assert_index_equal(ed.columns, exp_columns)
@@ -57,12 +57,12 @@ class TestEdgarIndex(tm.TestCase):
             ed = web.DataReader('daily', 'edgar-index', start='1998-05-18',
                                 end='1998-05-18')
             assert len(ed) < 1200
+            assert ed.index.nlevels == 2
 
-            self.assertEqual(ed.index.nlevels, 2)
             dti = ed.index.get_level_values(0)
-            self.assertIsInstance(dti, pd.DatetimeIndex)
-            self.assertEqual(dti[0], pd.Timestamp('1998-05-18'))
-            self.assertEqual(dti[-1], pd.Timestamp('1998-05-18'))
+            assert isinstance(dti, pd.DatetimeIndex)
+            assert dti[0] == pd.Timestamp('1998-05-18')
+            assert dti[-1] == pd.Timestamp('1998-05-18')
 
             exp_columns = pd.Index(['company_name', 'form_type',
                                     'filename'], dtype='object')

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -22,7 +22,7 @@ class TestEnigma(tm.TestCase):
         try:
             df = web.DataReader('enigma.inspections.restaurants.fl',
                                 'enigma', access_key=TEST_API_KEY)
-            self.assertTrue('serialid' in df.columns)
+            assert 'serialid' in df.columns
         except HTTPError as e:  # pragma: no cover
             pytest.skip(e)
 
@@ -30,18 +30,16 @@ class TestEnigma(tm.TestCase):
         try:
             df = pdr.get_data_enigma(
                 'enigma.inspections.restaurants.fl', TEST_API_KEY)
-            self.assertTrue('serialid' in df.columns)
+            assert 'serialid' in df.columns
         except HTTPError as e:  # pragma: no cover
             pytest.skip(e)
 
     def test_bad_key(self):
-        with tm.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             web.DataReader('enigma.inspections.restaurants.fl',
-                           'enigma',
-                           access_key=TEST_API_KEY + 'xxx')
+                           'enigma', access_key=TEST_API_KEY + 'xxx')
 
     def test_bad_url(self):
-        with tm.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             web.DataReader('enigma.inspections.restaurants.fllzzy',
-                           'enigma',
-                           access_key=TEST_API_KEY)
+                           'enigma', access_key=TEST_API_KEY)

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -13,8 +13,8 @@ class TestEurostat(tm.TestCase):
                             start=pd.Timestamp('2005-01-01'),
                             end=pd.Timestamp('2010-01-01'))
 
-        self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertEqual(df.shape, (2, 336))
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (2, 336)
 
         df = df['Percentage']['Total']['Natural sciences']
         df = df[['Norway', 'Poland', 'Portugal', 'Russia']]
@@ -40,7 +40,8 @@ class TestEurostat(tm.TestCase):
                             name='TIME_PERIOD')
         ne_name = ('Index, 2010=100',
                    'Building permits - m2 of useful floor area',
-                   'Unadjusted data (i.e. neither seasonally adjusted nor calendar adjusted data)',
+                   'Unadjusted data (i.e. neither seasonally adjusted nor '
+                   'calendar adjusted data)',
                    'Non-residential buildings, except office buildings',
                    'Netherlands', 'Annual')
         ne_values = [200.0, 186.5, 127.3, 130.7, 143.3, 147.8, 176.7,
@@ -49,7 +50,8 @@ class TestEurostat(tm.TestCase):
 
         uk_name = ('Index, 2010=100',
                    'Building permits - m2 of useful floor area',
-                   'Unadjusted data (i.e. neither seasonally adjusted nor calendar adjusted data)',
+                   'Unadjusted data (i.e. neither seasonally adjusted nor '
+                   'calendar adjusted data)',
                    'Non-residential buildings, except office buildings',
                    'United Kingdom', 'Annual')
         uk_values = [112.5, 113.3, 110.2, 112.1, 119.1, 112.7, 113.1,

--- a/pandas_datareader/tests/test_famafrench.py
+++ b/pandas_datareader/tests/test_famafrench.py
@@ -18,24 +18,24 @@ class TestFamaFrench(tm.TestCase):
 
         for name in keys:
             ff = web.DataReader(name, 'famafrench')
-            self.assertTrue('DESCR' in ff)
-            self.assertTrue(len(ff) > 1)
+            assert 'DESCR' in ff
+            assert len(ff) > 1
 
     def test_get_available_datasets(self):
         pytest.importorskip("lxml")
         l = get_available_datasets()
-        self.assertTrue(len(l) > 100)
+        assert len(l) > 100
 
     def test_index(self):
         ff = web.DataReader('F-F_Research_Data_Factors', 'famafrench')
-        self.assertEqual(ff[0].index.freq, 'M')
-        self.assertEqual(ff[1].index.freq, 'A-DEC')
+        assert ff[0].index.freq == 'M'
+        assert ff[1].index.freq == 'A-DEC'
 
     def test_f_f_research(self):
         results = web.DataReader("F-F_Research_Data_Factors", "famafrench",
                                  start='2010-01-01', end='2010-12-01')
-        self.assertTrue(isinstance(results, dict))
-        self.assertEqual(len(results), 3)
+        assert isinstance(results, dict)
+        assert len(results) == 3
 
         exp = pd.DataFrame({'Mkt-RF': [-3.36, 3.4, 6.31, 2., -7.89, -5.56,
                                        6.93, -4.77, 9.54, 3.88, 0.6, 6.82],
@@ -45,38 +45,45 @@ class TestFamaFrench(tm.TestCase):
                                     -1.96, -3.12, -2.52, -0.91, 3.78],
                             'RF': [0., 0., 0.01, 0.01, 0.01, 0.01, 0.01,
                                    0.01, 0.01, 0.01, 0.01, 0.01]},
-                           index=pd.period_range('2010-01-01', '2010-12-01', freq='M', name='Date'),
+                           index=pd.period_range('2010-01-01', '2010-12-01',
+                                                 freq='M', name='Date'),
                            columns=['Mkt-RF', 'SMB', 'HML', 'RF'])
         tm.assert_frame_equal(results[0], exp)
 
     def test_me_breakpoints(self):
         results = web.DataReader("ME_Breakpoints", "famafrench",
                                  start='2010-01-01', end='2010-12-01')
-        self.assertTrue(isinstance(results, dict))
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].shape, (12, 21))
+        assert isinstance(results, dict)
+        assert len(results) == 2
+        assert results[0].shape == (12, 21)
 
-        exp_columns = pd.Index(['Count', (0, 5), (5, 10), (10, 15), (15, 20), (20, 25),
-                                (25, 30), (30, 35), (35, 40), (40, 45), (45, 50), (50, 55),
-                                (55, 60), (60, 65), (65, 70), (70, 75), (75, 80), (80, 85),
-                                (85, 90), (90, 95), (95, 100)], dtype='object')
+        exp_columns = pd.Index(['Count', (0, 5), (5, 10), (10, 15), (15, 20),
+                                (20, 25), (25, 30), (30, 35), (35, 40),
+                                (40, 45), (45, 50), (50, 55), (55, 60),
+                                (60, 65), (65, 70), (70, 75), (75, 80),
+                                (80, 85), (85, 90), (90, 95), (95, 100)],
+                               dtype='object')
         tm.assert_index_equal(results[0].columns, exp_columns)
 
-        exp_index = pd.period_range('2010-01-01', '2010-12-01', freq='M', name='Date')
+        exp_index = pd.period_range('2010-01-01', '2010-12-01',
+                                    freq='M', name='Date')
         tm.assert_index_equal(results[0].index, exp_index)
 
     def test_prior_2_12_breakpoints(self):
         results = web.DataReader("Prior_2-12_Breakpoints", "famafrench",
                                  start='2010-01-01', end='2010-12-01')
-        self.assertTrue(isinstance(results, dict))
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].shape, (12, 22))
+        assert isinstance(results, dict)
+        assert len(results) == 2
+        assert results[0].shape == (12, 22)
 
-        exp_columns = pd.Index(['<=0', '>0', (0, 5), (5, 10), (10, 15), (15, 20), (20, 25),
-                                (25, 30), (30, 35), (35, 40), (40, 45), (45, 50), (50, 55),
-                                (55, 60), (60, 65), (65, 70), (70, 75), (75, 80), (80, 85),
-                                (85, 90), (90, 95), (95, 100)], dtype='object')
+        exp_columns = pd.Index(['<=0', '>0', (0, 5), (5, 10), (10, 15),
+                                (15, 20), (20, 25), (25, 30), (30, 35),
+                                (35, 40), (40, 45), (45, 50), (50, 55),
+                                (55, 60), (60, 65), (65, 70), (70, 75),
+                                (75, 80), (80, 85), (85, 90), (90, 95),
+                                (95, 100)], dtype='object')
         tm.assert_index_equal(results[0].columns, exp_columns)
 
-        exp_index = pd.period_range('2010-01-01', '2010-12-01', freq='M', name='Date')
+        exp_index = pd.period_range('2010-01-01', '2010-12-01',
+                                    freq='M', name='Date')
         tm.assert_index_equal(results[0].index, exp_index)

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -22,15 +22,16 @@ class TestFred(tm.TestCase):
 
         df = web.DataReader("GDP", "fred", start, end)
         ts = df['GDP']
-        self.assertEqual(ts.index[0], pd.to_datetime("2010-01-01"))
-        self.assertEqual(ts.index[-1], pd.to_datetime("2013-01-01"))
-        self.assertEqual(ts.index.name, "DATE")
-        self.assertEqual(ts.name, "GDP")
+
+        assert ts.index[0] == pd.to_datetime("2010-01-01")
+        assert ts.index[-1] == pd.to_datetime("2013-01-01")
+        assert ts.index.name == "DATE"
+        assert ts.name == "GDP"
 
         received = ts.tail(1)[0]
-        self.assertEqual(int(received), 16475)
+        assert int(received) == 16475
 
-        with tm.assertRaises(RemoteDataError):
+        with pytest.raises(RemoteDataError):
             web.DataReader("NON EXISTENT SERIES", 'fred', start, end)
 
     def test_fred_nan(self):
@@ -44,11 +45,11 @@ class TestFred(tm.TestCase):
         start = datetime(2010, 1, 1)
         end = datetime(2013, 1, 27)
         df = web.get_data_fred("CPIAUCSL", start, end)
-        self.assertEqual(df.ix['2010-05-01'][0], 217.23)
+        assert df.ix['2010-05-01'][0] == 217.23
 
         t = df.CPIAUCSL.values
         assert np.issubdtype(t.dtype, np.floating)
-        self.assertEqual(t.shape, (37,))
+        assert t.shape == (37,)
 
     def test_fred_part2(self):
         expected = [[576.7],
@@ -61,7 +62,8 @@ class TestFred(tm.TestCase):
 
     def test_invalid_series(self):
         name = "NOT A REAL SERIES"
-        self.assertRaises(Exception, web.get_data_fred, name)
+        with pytest.raises(Exception):
+            web.get_data_fred(name)
 
     @pytest.mark.skip(reason='Buggy as of 2/18/14; maybe a data revision?')
     def test_fred_multi(self):  # pragma: no cover
@@ -77,5 +79,5 @@ class TestFred(tm.TestCase):
 
     def test_fred_multi_bad_series(self):
         names = ['NOTAREALSERIES', 'CPIAUCSL', "ALSO FAKE"]
-        with tm.assertRaises(RemoteDataError):
+        with pytest.raises(RemoteDataError):
             web.DataReader(names, data_source="fred")

--- a/pandas_datareader/tests/test_google_options.py
+++ b/pandas_datareader/tests/test_google_options.py
@@ -19,36 +19,35 @@ class TestGoogleOptions(tm.TestCase):
         # goog has monthlies
         cls.goog = web.Options('GOOG', 'google')
 
-    def assert_option_result(self, df):
-        """
-        Validate returned option data has expected format.
-        """
-        self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertTrue(len(df) > 1)
+    def test_get_options_data(self):
+        try:
+            options = self.goog.get_options_data(
+                expiry=self.goog.expiry_dates[0])
+        except RemoteDataError as e:  # pragma: no cover
+            raise pytest.skip(e)
 
-        exp_columns = pd.Index(['Last', 'Bid', 'Ask', 'Chg', 'PctChg', 'Vol', 'Open_Int',
-                                'Root', 'Underlying_Price', 'Quote_Time'])
-        tm.assert_index_equal(df.columns, exp_columns)
-        tm.assert_equal(df.index.names, [u'Strike', u'Expiry', u'Type', u'Symbol'])
+        assert isinstance(options, pd.DataFrame)
+        assert len(options) > 10
+
+        exp_columns = pd.Index(['Last', 'Bid', 'Ask', 'Chg',
+                                'PctChg', 'Vol', 'Open_Int', 'Root',
+                                'Underlying_Price', 'Quote_Time'])
+
+        tm.assert_index_equal(options.columns, exp_columns)
+        assert options.index.names == [u'Strike', u'Expiry',
+                                       u'Type', u'Symbol']
 
         dtypes = ['float64'] * 7 + ['object', 'float64', 'datetime64[ns]']
         dtypes = [np.dtype(x) for x in dtypes]
-        tm.assert_series_equal(df.dtypes, pd.Series(dtypes, index=exp_columns))
 
-    def test_get_options_data(self):
-        try:
-            options = self.goog.get_options_data(expiry=self.goog.expiry_dates[0])
-        except RemoteDataError as e:  # pragma: no cover
-            raise pytest.skip(e)
-        self.assertTrue(len(options) > 10)
-
-        self.assert_option_result(options)
+        tm.assert_series_equal(options.dtypes, pd.Series(
+            dtypes, index=exp_columns))
 
         for typ in options.index.levels[2]:
-            self.assertTrue(typ in ['put', 'call'])
+            assert typ in ['put', 'call']
 
     def test_get_options_data_yearmonth(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_options_data(month=1, year=2016)
 
     def test_expiry_dates(self):
@@ -62,25 +61,25 @@ class TestGoogleOptions(tm.TestCase):
         assert all(isinstance(dt, date) for dt in dates)
 
     def test_get_call_data(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_call_data()
 
     def test_get_put_data(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_put_data()
 
     def test_get_near_stock_price(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_near_stock_price()
 
     def test_get_forward_data(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_forward_data([1, 2, 3])
 
     def test_get_all_data(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_all_data()
 
     def test_get_options_data_with_year(self):
-        with tm.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             self.goog.get_options_data(year=2016)

--- a/pandas_datareader/tests/test_oecd.py
+++ b/pandas_datareader/tests/test_oecd.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from pandas_datareader._utils import RemoteDataError
+
+import pytest
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
-from pandas_datareader._utils import RemoteDataError
 
 
 class TestOECD(tm.TestCase):
@@ -80,8 +82,8 @@ class TestOECD(tm.TestCase):
                                    expected)
 
     def test_oecd_invalid_symbol(self):
-        with tm.assertRaises(RemoteDataError):
+        with pytest.raises(RemoteDataError):
             web.DataReader('INVALID_KEY', 'oecd')
 
-        with tm.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             web.DataReader(1234, 'oecd')

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -19,20 +19,23 @@ class TestWB(tm.TestCase):
         # results actually are.  The fact that there are some, is good enough.
 
         result = search('gdp.*capita.*constant')
-        self.assertTrue(result.name.str.contains('GDP').any())
+        assert result.name.str.contains('GDP').any()
 
         # check cache returns the results within 0.5 sec
         current_time = time.time()
         result = search('gdp.*capita.*constant')
-        self.assertTrue(result.name.str.contains('GDP').any())
-        self.assertTrue(time.time() - current_time < 0.5)
+        assert result.name.str.contains('GDP').any()
+        assert time.time() - current_time < 0.5
 
         result2 = WorldBankReader().search('gdp.*capita.*constant')
         session = requests.Session()
+
         result3 = search('gdp.*capita.*constant', session=session)
-        result4 = WorldBankReader(session=session).search('gdp.*capita.*constant')
+        result4 = WorldBankReader(session=session).search(
+            'gdp.*capita.*constant')
+
         for result in [result2, result3, result4]:
-            self.assertTrue(result.name.str.contains('GDP').any())
+            assert result.name.str.contains('GDP').any()
 
     def test_wdi_download(self):
 
@@ -110,29 +113,31 @@ class TestWB(tm.TestCase):
         cntry_codes = ['USA', 'XX']
         inds = 'NY.GDP.PCAP.CD'
 
-        with tm.assertRaisesRegexp(ValueError, "Invalid Country Code\\(s\\): XX"):
+        with tm.assertRaisesRegexp(ValueError,
+                                   "Invalid Country Code\\(s\\): XX"):
             download(country=cntry_codes, indicator=inds,
                      start=2003, end=2004, errors='raise')
 
-        # assert_produces_warning doesn't exists in prior versions
-        with self.assert_produces_warning():
+        with tm.assert_produces_warning():
             result = download(country=cntry_codes, indicator=inds,
                               start=2003, end=2004, errors='warn')
-            self.assertTrue(isinstance(result, pd.DataFrame))
-            self.assertEqual(len(result), 2)
+            assert isinstance(result, pd.DataFrame)
+            assert len(result), 2
 
         cntry_codes = ['USA']
         inds = ['NY.GDP.PCAP.CD', 'BAD_INDICATOR']
 
-        with tm.assertRaisesRegexp(ValueError, "The provided parameter value is not valid\\. Indicator: BAD_INDICATOR"):
+        with tm.assertRaisesRegexp(ValueError,
+                                   "The provided parameter value is not "
+                                   "valid\\. Indicator: BAD_INDICATOR"):
             download(country=cntry_codes, indicator=inds,
                      start=2003, end=2004, errors='raise')
 
-        with self.assert_produces_warning():
+        with tm.assert_produces_warning():
             result = download(country=cntry_codes, indicator=inds,
                               start=2003, end=2004, errors='warn')
-            self.assertTrue(isinstance(result, pd.DataFrame))
-            self.assertEqual(len(result), 2)
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 2
 
     def test_wdi_download_w_retired_indicator(self):
 
@@ -189,10 +194,10 @@ class TestWB(tm.TestCase):
         result4 = WorldBankReader(session=session).get_countries()
 
         for result in [result1, result2, result3, result4]:
-            self.assertTrue('Zimbabwe' in list(result['name']))
-            self.assertTrue(len(result) > 100)
-            self.assertTrue(pd.notnull(result.latitude.mean()))
-            self.assertTrue(pd.notnull(result.longitude.mean()))
+            assert 'Zimbabwe' in list(result['name'])
+            assert len(result) > 100
+            assert pd.notnull(result.latitude.mean())
+            assert pd.notnull(result.longitude.mean())
 
     def test_wdi_get_indicators(self):
         result1 = get_indicators()
@@ -203,7 +208,8 @@ class TestWB(tm.TestCase):
         result4 = WorldBankReader(session=session).get_indicators()
 
         for result in [result1, result2, result3, result4]:
-            exp_col = pd.Index(['id', 'name', 'source', 'sourceNote', 'sourceOrganization', 'topics'])
+            exp_col = pd.Index(['id', 'name', 'source', 'sourceNote',
+                                'sourceOrganization', 'topics'])
             # assert_index_equal doesn't exists
-            self.assertTrue(result.columns.equals(exp_col))
-            self.assertTrue(len(result) > 10000)
+            assert result.columns.equals(exp_col)
+            assert len(result) > 10000

--- a/pandas_datareader/tests/test_yahoo.py
+++ b/pandas_datareader/tests/test_yahoo.py
@@ -7,7 +7,6 @@ from pandas import DataFrame
 
 import pytest
 import pandas.util.testing as tm
-from pandas.util.testing import (assert_series_equal, assert_frame_equal)
 
 import pandas_datareader.data as web
 from pandas_datareader.data import YahooDailyReader
@@ -21,46 +20,44 @@ class TestYahoo(tm.TestCase):
         pytest.importorskip("lxml")
 
     def test_yahoo(self):
-        # asserts that yahoo is minimally working and that it throws
-        # an exception when DataReader can't get a 200 response from
-        # yahoo
+        # Asserts that yahoo is minimally working
         start = datetime(2010, 1, 1)
         end = datetime(2013, 1, 27)
 
-        self.assertEqual(web.DataReader("F", 'yahoo', start, end)['Close'][-1],
-                         13.68)
+        assert web.DataReader('F', 'yahoo', start, end)['Close'][-1] == 13.68
 
     def test_yahoo_fails(self):
         start = datetime(2010, 1, 1)
         end = datetime(2013, 1, 27)
-        self.assertRaises(Exception, web.DataReader, "NON EXISTENT TICKER",
-                          'yahoo', start, end)
+
+        with pytest.raises(Exception):
+            web.DataReader('NON EXISTENT TICKER', 'yahoo', start, end)
 
     def test_get_quote_series(self):
         df = web.get_quote_yahoo(pd.Series(['GOOG', 'AAPL', 'GOOG']))
-        assert_series_equal(df.ix[0], df.ix[2])
+        tm.assert_series_equal(df.ix[0], df.ix[2])
 
     def test_get_quote_string(self):
         _yahoo_codes.update({'MarketCap': 'j1'})
         df = web.get_quote_yahoo('GOOG')
-        self.assertFalse(pd.isnull(df['MarketCap'][0]))
+        assert not pd.isnull(df['MarketCap'][0])
 
     def test_get_quote_stringlist(self):
         df = web.get_quote_yahoo(['GOOG', 'AAPL', 'GOOG'])
-        assert_series_equal(df.ix[0], df.ix[2])
+        tm.assert_series_equal(df.ix[0], df.ix[2])
 
     def test_get_quote_comma_name(self):
         _yahoo_codes.update({'name': 'n'})
         df = web.get_quote_yahoo(['RGLD'])
         del _yahoo_codes['name']
-        self.assertEqual(df['name'][0], 'Royal Gold, Inc.')
+        assert df['name'][0] == 'Royal Gold, Inc.'
 
     @pytest.mark.skip('Unreliable test, receive partial '
                       'components back for dow_jones')
     def test_get_components_dow_jones(self):  # pragma: no cover
         df = web.get_components_yahoo('^DJI')  # Dow Jones
         assert isinstance(df, pd.DataFrame)
-        self.assertEqual(len(df), 30)
+        assert len(df) == 30
 
     @pytest.mark.skip('Unreliable test, receive partial '
                       'components back for dax')
@@ -68,9 +65,8 @@ class TestYahoo(tm.TestCase):
         df = web.get_components_yahoo('^GDAXI')  # DAX
         assert isinstance(df, pd.DataFrame)
 
-        self.assertEqual(len(df), 30)
-        self.assertEqual(df[df.name.str.contains('adidas', case=False)].index,
-                         'ADS.DE')
+        assert len(df) == 30
+        assert df[df.name.str.contains('adidas', case=False)].index == 'ADS.DE'
 
     @pytest.mark.skip('Unreliable test, receive partial '
                       'components back for nasdaq_100')
@@ -89,7 +85,7 @@ class TestYahoo(tm.TestCase):
         else:
             expected = DataFrame({'exchange': 'N/A', 'name': '@^NDX'},
                                  index=['@^NDX'])
-            assert_frame_equal(df, expected)
+            tm.assert_frame_equal(df, expected)
 
     def test_get_data_single_symbol(self):
         # single symbol
@@ -100,28 +96,33 @@ class TestYahoo(tm.TestCase):
     def test_get_data_adjust_price(self):
         goog = web.get_data_yahoo('GOOG')
         goog_adj = web.get_data_yahoo('GOOG', adjust_price=True)
-        self.assertTrue('Adj Close' not in goog_adj.columns)
-        self.assertTrue((goog['Open'] * goog_adj['Adj_Ratio']).equals(goog_adj['Open']))
+        assert 'Adj Close' not in goog_adj.columns
+        assert (goog['Open'] * goog_adj['Adj_Ratio']).equals(goog_adj['Open'])
 
     def test_get_data_interval(self):
         # daily interval data
-        pan = web.get_data_yahoo('XOM', '2013-01-01', '2013-12-31', interval='d')
-        self.assertEqual(len(pan), 252)
+        pan = web.get_data_yahoo('XOM', '2013-01-01',
+                                 '2013-12-31', interval='d')
+        assert len(pan) == 252
 
         # weekly interval data
-        pan = web.get_data_yahoo('XOM', '2013-01-01', '2013-12-31', interval='w')
-        self.assertEqual(len(pan), 53)
+        pan = web.get_data_yahoo('XOM', '2013-01-01',
+                                 '2013-12-31', interval='w')
+        assert len(pan) == 53
 
         # montly interval data
-        pan = web.get_data_yahoo('XOM', '2013-01-01', '2013-12-31', interval='m')
-        self.assertEqual(len(pan), 12)
+        pan = web.get_data_yahoo('XOM', '2013-01-01',
+                                 '2013-12-31', interval='m')
+        assert len(pan) == 12
 
         # dividend data
-        pan = web.get_data_yahoo('XOM', '2013-01-01', '2013-12-31', interval='v')
-        self.assertEqual(len(pan), 4)
+        pan = web.get_data_yahoo('XOM', '2013-01-01',
+                                 '2013-12-31', interval='v')
+        assert len(pan) == 4
 
         # test fail on invalid interval
-        self.assertRaises(ValueError, web.get_data_yahoo, 'XOM', interval='NOT VALID')
+        with pytest.raises(ValueError):
+            web.get_data_yahoo('XOM', interval='NOT VALID')
 
     def test_get_data_multiple_symbols(self):
         # just test that we succeed
@@ -132,7 +133,7 @@ class TestYahoo(tm.TestCase):
         pan = web.get_data_yahoo(['GE', 'MSFT', 'INTC'], 'JAN-01-12',
                                  'JAN-31-12')
         result = pan.Close.ix['01-18-12']
-        self.assertEqual(len(result), 3)
+        assert len(result) == 3
 
         # sanity checking
         assert np.issubdtype(result.dtype, np.floating)
@@ -142,16 +143,17 @@ class TestYahoo(tm.TestCase):
                              [19.03, 28.16, 25.52],
                              [18.81, 28.82, 25.87]])
         result = pan.Open.ix['Jan-15-12':'Jan-20-12']
-        self.assertEqual(expected.shape, result.shape)
+        assert expected.shape == result.shape
 
     def test_get_date_ret_index(self):
         pan = web.get_data_yahoo(['GE', 'INTC', 'IBM'], '1977', '1987',
                                  ret_index=True)
-        self.assertTrue(hasattr(pan, 'Ret_Index'))
+        assert hasattr(pan, 'Ret_Index')
+
         if hasattr(pan, 'Ret_Index') and hasattr(pan.Ret_Index, 'INTC'):
             tstamp = pan.Ret_Index.INTC.first_valid_index()
             result = pan.Ret_Index.ix[tstamp]['INTC']
-            self.assertEqual(result, 1.0)
+            assert result == 1.0
 
         # sanity checking
         assert np.issubdtype(pan.values.dtype, np.floating)
@@ -162,48 +164,59 @@ class TestYahoo(tm.TestCase):
 
         actions = web.get_data_yahoo_actions('BHP.AX', start, end)
 
-        self.assertEqual(sum(actions['action'] == 'DIVIDEND'), 20)
-        self.assertEqual(sum(actions['action'] == 'SPLIT'), 1)
+        assert sum(actions['action'] == 'DIVIDEND') == 20
+        assert sum(actions['action'] == 'SPLIT') == 1
 
-        self.assertEqual(actions.ix['1995-05-11']['action'][0], 'SPLIT')
-        self.assertEqual(actions.ix['1995-05-11']['value'][0], 1 / 1.1)
+        assert actions.ix['1995-05-11']['action'][0] == 'SPLIT'
+        assert actions.ix['1995-05-11']['value'][0] == 1 / 1.1
 
-        self.assertEqual(actions.ix['1993-05-10']['action'][0], 'DIVIDEND')
-        self.assertEqual(actions.ix['1993-05-10']['value'][0], 0.3)
+        assert actions.ix['1993-05-10']['action'][0] == 'DIVIDEND'
+        assert actions.ix['1993-05-10']['value'][0] == 0.3
 
     def test_get_data_yahoo_actions_invalid_symbol(self):
         start = datetime(1990, 1, 1)
         end = datetime(2000, 4, 5)
 
-        self.assertRaises(IOError, web.get_data_yahoo_actions, 'UNKNOWN TICKER', start, end)
+        with pytest.raises(IOError):
+            web.get_data_yahoo_actions('UNKNOWN TICKER', start, end)
 
     def test_yahoo_reader_class(self):
         r = YahooDailyReader('GOOG')
         df = r.read()
-        self.assertEqual(df.Volume.loc['JAN-02-2015'], 1447500)
+
+        assert df.Volume.loc['JAN-02-2015'] == 1447500
 
         session = requests.Session()
+
         r = YahooDailyReader('GOOG', session=session)
-        self.assertTrue(r.session is session)
+        assert r.session is session
 
     def test_yahoo_DataReader(self):
         start = datetime(2010, 1, 1)
         end = datetime(2015, 5, 9)
         result = web.DataReader('AAPL', 'yahoo-actions', start, end)
 
-        exp_idx = pd.DatetimeIndex(['2015-05-07', '2015-02-05', '2014-11-06', '2014-08-07',
-                                    '2014-06-09', '2014-05-08', '2014-02-06', '2013-11-06',
-                                    '2013-08-08', '2013-05-09', '2013-02-07', '2012-11-07',
+        exp_idx = pd.DatetimeIndex(['2015-05-07', '2015-02-05',
+                                    '2014-11-06', '2014-08-07',
+                                    '2014-06-09', '2014-05-08',
+                                    '2014-02-06', '2013-11-06',
+                                    '2013-08-08', '2013-05-09',
+                                    '2013-02-07', '2012-11-07',
                                     '2012-08-09'])
-        exp = pd.DataFrame({'action': ['DIVIDEND', 'DIVIDEND', 'DIVIDEND', 'DIVIDEND',
-                                       'SPLIT', 'DIVIDEND', 'DIVIDEND', 'DIVIDEND',
-                                       'DIVIDEND', 'DIVIDEND', 'DIVIDEND', 'DIVIDEND', 'DIVIDEND'],
-                            'value': [0.52, 0.47, 0.47, 0.47, 0.14285714, 0.47, 0.43571, 0.43571,
-                                      0.43571, 0.43571, 0.37857, 0.37857, 0.37857]}, index=exp_idx)
+        exp = pd.DataFrame({'action': ['DIVIDEND', 'DIVIDEND', 'DIVIDEND',
+                                       'DIVIDEND', 'SPLIT', 'DIVIDEND',
+                                       'DIVIDEND', 'DIVIDEND',
+                                       'DIVIDEND', 'DIVIDEND', 'DIVIDEND',
+                                       'DIVIDEND', 'DIVIDEND'],
+                            'value': [0.52, 0.47, 0.47, 0.47, 0.14285714,
+                                      0.47, 0.43571, 0.43571, 0.43571,
+                                      0.43571, 0.37857, 0.37857, 0.37857]},
+                           index=exp_idx)
         tm.assert_frame_equal(result, exp)
 
     def test_yahoo_DataReader_multi(self):
         start = datetime(2010, 1, 1)
         end = datetime(2015, 5, 9)
+
         result = web.DataReader(['AAPL', 'F'], 'yahoo-actions', start, end)
         assert isinstance(result, pd.Panel)

--- a/pandas_datareader/tests/test_yahoo_options.py
+++ b/pandas_datareader/tests/test_yahoo_options.py
@@ -18,18 +18,24 @@ class TestYahooOptions(tm.TestCase):
     def setUpClass(cls):
         super(TestYahooOptions, cls).setUpClass()
 
-        # aapl has monthlies
+        # AAPL has monthlies
         cls.aapl = web.Options('aapl', 'yahoo')
         today = datetime.today()
         cls.year = today.year
         cls.month = today.month + 1
+
         if cls.month > 12:  # pragma: no cover
             cls.month = 1
             cls.year = cls.year + 1
+
         cls.expiry = datetime(cls.year, cls.month, 1)
         cls.dirpath = tm.get_data_path()
-        cls.json1 = 'file://' + os.path.join(cls.dirpath, 'yahoo_options1.json')
-        cls.json2 = 'file://' + os.path.join(cls.dirpath, 'yahoo_options2.json')  # Empty table GH#22
+        cls.json1 = 'file://' + os.path.join(
+            cls.dirpath, 'yahoo_options1.json')
+
+        # see gh-22: empty table
+        cls.json2 = 'file://' + os.path.join(
+            cls.dirpath, 'yahoo_options2.json')
         cls.data1 = cls.aapl._process_data(cls.aapl._parse_url(cls.json1))
 
     @classmethod
@@ -41,26 +47,28 @@ class TestYahooOptions(tm.TestCase):
         """
         Validate returned option data has expected format.
         """
-        self.assertTrue(isinstance(df, pd.DataFrame))
-        self.assertTrue(len(df) > 1)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 1
 
-        exp_columns = pd.Index(['Last', 'Bid', 'Ask', 'Chg', 'PctChg', 'Vol', 'Open_Int',
-                                'IV', 'Root', 'IsNonstandard', 'Underlying',
-                                'Underlying_Price', 'Quote_Time', 'Last_Trade_Date', 'JSON'])
+        exp_columns = pd.Index(['Last', 'Bid', 'Ask', 'Chg', 'PctChg', 'Vol',
+                                'Open_Int', 'IV', 'Root', 'IsNonstandard',
+                                'Underlying', 'Underlying_Price', 'Quote_Time',
+                                'Last_Trade_Date', 'JSON'])
         tm.assert_index_equal(df.columns, exp_columns)
-        tm.assert_equal(df.index.names, [u'Strike', u'Expiry', u'Type', u'Symbol'])
+        tm.assert_equal(df.index.names, [u'Strike', u'Expiry',
+                                         u'Type', u'Symbol'])
 
         dtypes = [np.dtype(x) for x in ['float64'] * 7 +
-                  ['float64', 'object', 'bool', 'object', 'float64', 'datetime64[ns]',
-                   'datetime64[ns]', 'object']]
+                  ['float64', 'object', 'bool', 'object', 'float64',
+                   'datetime64[ns]', 'datetime64[ns]', 'object']]
         tm.assert_series_equal(df.dtypes, pd.Series(dtypes, index=exp_columns))
 
     def test_get_options_data(self):
-        # regression test GH6105
-        with tm.assertRaises(ValueError):
+        # see gh-6105: regression test
+        with pytest.raises(ValueError):
             self.aapl.get_options_data(month=3)
 
-        with tm.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.aapl.get_options_data(year=1992)
 
         try:
@@ -81,7 +89,7 @@ class TestYahooOptions(tm.TestCase):
 
     def test_options_is_not_none(self):
         option = web.Options('aapl', 'yahoo')
-        self.assertTrue(option is not None)
+        assert option is not None
 
     def test_get_call_data(self):
         try:
@@ -90,7 +98,7 @@ class TestYahooOptions(tm.TestCase):
             pytest.skip(e)
 
         self.assert_option_result(calls)
-        self.assertTrue(calls.index.levels[2][0], 'call')
+        assert calls.index.levels[2][0] == 'call'
 
     def test_get_put_data(self):
         try:
@@ -99,22 +107,23 @@ class TestYahooOptions(tm.TestCase):
             pytest.skip(e)
 
         self.assert_option_result(puts)
-        self.assertTrue(puts.index.levels[2][0], 'put')
+        assert puts.index.levels[2][1] == 'put'
 
     def test_get_expiry_dates(self):
         try:
             dates = self.aapl._get_expiry_dates()
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
-        self.assertTrue(len(dates) > 1)
+
+        assert len(dates) > 1
 
     def test_get_all_data(self):
         try:
             data = self.aapl.get_all_data(put=True)
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
-        self.assertTrue(len(data) > 1)
 
+        assert len(data) > 1
         self.assert_option_result(data)
 
     def test_get_data_with_list(self):
@@ -122,8 +131,8 @@ class TestYahooOptions(tm.TestCase):
             data = self.aapl.get_call_data(expiry=self.aapl.expiry_dates)
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
-        self.assertTrue(len(data) > 1)
 
+        assert len(data) > 1
         self.assert_option_result(data)
 
     def test_get_all_data_calls_only(self):
@@ -131,61 +140,73 @@ class TestYahooOptions(tm.TestCase):
             data = self.aapl.get_all_data(call=True, put=False)
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
-        self.assertTrue(len(data) > 1)
 
+        assert len(data) > 1
         self.assert_option_result(data)
 
     def test_get_underlying_price(self):
-        # GH7
+        # see gh-7
+
         try:
             options_object = web.Options('^spxpm', 'yahoo')
             quote_price = options_object.underlying_price
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
-        self.assertTrue(isinstance(quote_price, float))
+
+        assert isinstance(quote_price, float)
 
         # Tests the weekend quote time format
         price, quote_time = self.aapl.underlying_price, self.aapl.quote_time
-        self.assertTrue(isinstance(price, (int, float, complex)))
-        self.assertTrue(isinstance(quote_time, (datetime, pd.Timestamp)))
+
+        assert isinstance(price, (int, float, complex))
+        assert isinstance(quote_time, (datetime, pd.Timestamp))
 
     def test_chop(self):
-        # regression test for #7625
-        self.aapl._chop_data(self.data1, above_below=2, underlying_price=np.nan)
-        chopped = self.aapl._chop_data(self.data1, above_below=2, underlying_price=100)
-        self.assertTrue(isinstance(chopped, pd.DataFrame))
-        self.assertTrue(len(chopped) > 1)
-        chopped2 = self.aapl._chop_data(self.data1, above_below=2, underlying_price=None)
-        self.assertTrue(isinstance(chopped2, pd.DataFrame))
-        self.assertTrue(len(chopped2) > 1)
+        # gh-7625: regression test
+        self.aapl._chop_data(self.data1, above_below=2,
+                             underlying_price=np.nan)
+        chopped = self.aapl._chop_data(self.data1, above_below=2,
+                                       underlying_price=100)
+
+        assert isinstance(chopped, pd.DataFrame)
+        assert len(chopped) > 1
+
+        chopped2 = self.aapl._chop_data(self.data1, above_below=2,
+                                        underlying_price=None)
+
+        assert isinstance(chopped2, pd.DataFrame)
+        assert len(chopped2) > 1
 
     def test_chop_out_of_strike_range(self):
-        # regression test for #7625
-        self.aapl._chop_data(self.data1, above_below=2, underlying_price=np.nan)
-        chopped = self.aapl._chop_data(self.data1, above_below=2, underlying_price=100000)
-        self.assertTrue(isinstance(chopped, pd.DataFrame))
-        self.assertTrue(len(chopped) > 1)
+        # gh-7625: regression test
+        self.aapl._chop_data(self.data1, above_below=2,
+                             underlying_price=np.nan)
+        chopped = self.aapl._chop_data(self.data1, above_below=2,
+                                       underlying_price=100000)
+
+        assert isinstance(chopped, pd.DataFrame)
+        assert len(chopped) > 1
 
     def test_sample_page_chg_float(self):
         # Tests that numeric columns with comma's are appropriately dealt with
-        self.assertEqual(self.data1['Chg'].dtype, 'float64')
+        assert self.data1['Chg'].dtype == 'float64'
 
     def test_month_year(self):
-
+        # see gh-168
         try:
             data = self.aapl.get_call_data(month=self.month, year=self.year)
         except RemoteDataError as e:  # pragma: no cover
             pytest.skip(e)
 
-        self.assertTrue(len(data) > 1)
+        assert len(data) > 1
 
         if sys.version_info[0] == 2 and sys.version_info[1] == 6:
             pytest.skip('skip dtype check in python 2.6')
-        self.assertEqual(data.index.levels[0].dtype, 'float64')  # GH168
+        assert data.index.levels[0].dtype == 'float64'
 
         self.assert_option_result(data)
 
     def test_empty_table(self):
-        # GH22
+        # see gh-22
         empty = self.aapl._process_data(self.aapl._parse_url(self.json2))
-        self.assertTrue(len(empty) == 0)
+        assert len(empty) == 0


### PR DESCRIPTION
Title is self-explanatory.

Remaining instances are those where an `assert*` function was defined directly in the class.