### PR TITLE
COMPAT, TST: Remove tm.TestCase from testing

### DIFF
--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -8,11 +8,17 @@ from distutils.version import LooseVersion
 PANDAS_VERSION = LooseVersion(pd.__version__)
 
 PANDAS_0190 = (PANDAS_VERSION >= LooseVersion('0.19.0'))
+PANDAS_0200 = (PANDAS_VERSION >= LooseVersion('0.20.0'))
 
 if PANDAS_0190:
     from pandas.api.types import is_number
 else:
     from pandas.core.common import is_number
+
+if PANDAS_0200:
+    from pandas.util.testing import assert_raises_regex
+else:
+    from pandas.util.testing import assertRaisesRegexp as assert_raises_regex
 
 if compat.PY3:
     from urllib.error import HTTPError

--- a/pandas_datareader/io/tests/test_jsdmx.py
+++ b/pandas_datareader/io/tests/test_jsdmx.py
@@ -9,9 +9,9 @@ import pandas.util.testing as tm
 from pandas_datareader.io import read_jsdmx
 
 
-class TestJSDMX(tm.TestCase):
+class TestJSDMX(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
 
     def test_tourism(self):

--- a/pandas_datareader/io/tests/test_sdmx.py
+++ b/pandas_datareader/io/tests/test_sdmx.py
@@ -9,9 +9,9 @@ import pandas.util.testing as tm
 from pandas_datareader.io.sdmx import read_sdmx, _read_sdmx_dsd
 
 
-class TestSDMX(tm.TestCase):
+class TestSDMX(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
 
     def test_tourism(self):

--- a/pandas_datareader/tests/test_base.py
+++ b/pandas_datareader/tests/test_base.py
@@ -1,9 +1,8 @@
 import pytest
-import pandas.util.testing as tm
 import pandas_datareader.base as base
 
 
-class TestBaseReader(tm.TestCase):
+class TestBaseReader(object):
     def test_valid_retry_count(self):
         with pytest.raises(ValueError):
             base._BaseReader([], retry_count='stuff')
@@ -21,7 +20,7 @@ class TestBaseReader(tm.TestCase):
             b._read_one_data('a', None)
 
 
-class TestDailyBaseReader(tm.TestCase):
+class TestDailyBaseReader(object):
     def test_get_params(self):
         with pytest.raises(NotImplementedError):
             b = base._DailyBaseReader()

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -7,21 +7,14 @@ from pandas import DataFrame
 from pandas_datareader.data import DataReader
 
 
-class TestOptionsWarnings(tm.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestOptionsWarnings, cls).setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestOptionsWarnings, cls).tearDownClass()
+class TestOptionsWarnings(object):
 
     def test_options_source_warning(self):
         with tm.assert_produces_warning():
             web.Options('aapl')
 
 
-class TestDataReader(tm.TestCase):
+class TestDataReader(object):
     def test_read_yahoo(self):
         gs = DataReader("GS", "yahoo")
         assert isinstance(gs, DataFrame)

--- a/pandas_datareader/tests/test_edgar.py
+++ b/pandas_datareader/tests/test_edgar.py
@@ -7,7 +7,7 @@ import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
 
 
-class TestEdgarIndex(tm.TestCase):
+class TestEdgarIndex(object):
 
     @classmethod
     def setup_class(cls):

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -3,19 +3,16 @@ import pytest
 
 from requests.exceptions import HTTPError
 
-import pandas.util.testing as tm
-
 import pandas_datareader as pdr
 import pandas_datareader.data as web
 
 TEST_API_KEY = os.getenv('ENIGMA_API_KEY')
 
 
-class TestEnigma(tm.TestCase):
+class TestEnigma(object):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEnigma, cls).setUpClass()
+    def setup_class(cls):
         pytest.importorskip("lxml")
 
     def test_enigma_datareader(self):

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
 
+from pandas_datareader.compat import assert_raises_regex
+
 
 class TestEurostat(tm.TestCase):
 
@@ -87,7 +89,7 @@ class TestEurostat(tm.TestCase):
     def test_get_prc_hicp_manr_exceeds_limit(self):
         # see gh-149
         msg = 'Query size exceeds maximum limit'
-        with tm.assertRaisesRegexp(ValueError, msg):
+        with assert_raises_regex(ValueError, msg):
             web.DataReader('prc_hicp_manr', 'eurostat',
                            start=pd.Timestamp('2000-01-01'),
                            end=pd.Timestamp('2013-01-01'))

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -6,7 +6,7 @@ import pandas_datareader.data as web
 from pandas_datareader.compat import assert_raises_regex
 
 
-class TestEurostat(tm.TestCase):
+class TestEurostat(object):
 
     def test_get_cdh_e_fos(self):
         # Employed doctorate holders in non managerial and non professional

--- a/pandas_datareader/tests/test_famafrench.py
+++ b/pandas_datareader/tests/test_famafrench.py
@@ -7,7 +7,7 @@ import pandas_datareader.data as web
 from pandas_datareader.famafrench import get_available_datasets
 
 
-class TestFamaFrench(tm.TestCase):
+class TestFamaFrench(object):
 
     def test_get_data(self):
         keys = [

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -11,7 +11,7 @@ from pandas import DataFrame
 from pandas_datareader._utils import RemoteDataError
 
 
-class TestFred(tm.TestCase):
+class TestFred(object):
     def test_fred(self):
 
         # Raises an exception when DataReader can't

--- a/pandas_datareader/tests/test_google.py
+++ b/pandas_datareader/tests/test_google.py
@@ -30,18 +30,16 @@ def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     assert msgs.str.contains('|'.join(failed_symbols)).all()
 
 
-class TestGoogle(tm.TestCase):
+class TestGoogle(object):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestGoogle, cls).setUpClass()
+    def setup_class(cls):
         cls.locales = tm.get_locales(prefix='en_US')
         if not cls.locales:  # pragma: no cover
             pytest.skip("US English locale not available for testing")
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestGoogle, cls).tearDownClass()
+    def teardown_class(cls):
         del cls.locales
 
     def test_google(self):

--- a/pandas_datareader/tests/test_google_options.py
+++ b/pandas_datareader/tests/test_google_options.py
@@ -10,13 +10,11 @@ import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
 
 
-class TestGoogleOptions(tm.TestCase):
+class TestGoogleOptions(object):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestGoogleOptions, cls).setUpClass()
-
-        # goog has monthlies
+    def setup_class(cls):
+        # GOOG has monthlies
         cls.goog = web.Options('GOOG', 'google')
 
     def test_get_options_data(self):

--- a/pandas_datareader/tests/test_nasdaq.py
+++ b/pandas_datareader/tests/test_nasdaq.py
@@ -1,11 +1,10 @@
 import pytest
-import pandas.util.testing as tm
 import pandas_datareader.data as web
 
 from pandas_datareader._utils import RemoteDataError
 
 
-class TestNasdaqSymbols(tm.TestCase):
+class TestNasdaqSymbols(object):
 
     def test_get_symbols(self):
         try:

--- a/pandas_datareader/tests/test_oecd.py
+++ b/pandas_datareader/tests/test_oecd.py
@@ -8,7 +8,7 @@ import pandas.util.testing as tm
 import pandas_datareader.data as web
 
 
-class TestOECD(tm.TestCase):
+class TestOECD(object):
 
     def test_get_un_den(self):
         df = web.DataReader('UN_DEN', 'oecd', start=datetime(1960, 1, 1),

--- a/pandas_datareader/tests/test_tsp.py
+++ b/pandas_datareader/tests/test_tsp.py
@@ -1,10 +1,9 @@
-import pandas.util.testing as tm
 import datetime as dt
 
 import pandas_datareader.tsp as tsp
 
 
-class TestTSPFunds(tm.TestCase):
+class TestTSPFunds(object):
     def test_get_allfunds(self):
         tspdata = tsp.TSPReader(start='2015-11-2', end='2015-11-2').read()
 

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -3,11 +3,12 @@ import pytest
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
 import requests
 
+import pandas.util.testing as tm
 from pandas_datareader.wb import (search, download, get_countries,
                                   get_indicators, WorldBankReader)
+from pandas_datareader.compat import assert_raises_regex
 
 
 class TestWB(tm.TestCase):
@@ -113,8 +114,8 @@ class TestWB(tm.TestCase):
         cntry_codes = ['USA', 'XX']
         inds = 'NY.GDP.PCAP.CD'
 
-        with tm.assertRaisesRegexp(ValueError,
-                                   "Invalid Country Code\\(s\\): XX"):
+        msg = "Invalid Country Code\\(s\\): XX"
+        with assert_raises_regex(ValueError, msg):
             download(country=cntry_codes, indicator=inds,
                      start=2003, end=2004, errors='raise')
 
@@ -127,9 +128,9 @@ class TestWB(tm.TestCase):
         cntry_codes = ['USA']
         inds = ['NY.GDP.PCAP.CD', 'BAD_INDICATOR']
 
-        with tm.assertRaisesRegexp(ValueError,
-                                   "The provided parameter value is not "
-                                   "valid\\. Indicator: BAD_INDICATOR"):
+        msg = ("The provided parameter value is not valid\\. "
+               "Indicator: BAD_INDICATOR")
+        with assert_raises_regex(ValueError, msg):
             download(country=cntry_codes, indicator=inds,
                      start=2003, end=2004, errors='raise')
 

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -11,7 +11,7 @@ from pandas_datareader.wb import (search, download, get_countries,
 from pandas_datareader.compat import assert_raises_regex
 
 
-class TestWB(tm.TestCase):
+class TestWB(object):
 
     def test_wdi_search(self):
 

--- a/pandas_datareader/tests/test_yahoo.py
+++ b/pandas_datareader/tests/test_yahoo.py
@@ -13,10 +13,10 @@ from pandas_datareader.data import YahooDailyReader
 from pandas_datareader.yahoo.quotes import _yahoo_codes
 
 
-class TestYahoo(tm.TestCase):
+class TestYahoo(object):
+
     @classmethod
-    def setUpClass(cls):
-        super(TestYahoo, cls).setUpClass()
+    def setup_class(cls):
         pytest.importorskip("lxml")
 
     def test_yahoo(self):

--- a/pandas_datareader/tests/test_yahoo_options.py
+++ b/pandas_datareader/tests/test_yahoo_options.py
@@ -12,12 +12,10 @@ import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
 
 
-class TestYahooOptions(tm.TestCase):
+class TestYahooOptions(object):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestYahooOptions, cls).setUpClass()
-
+    def setup_class(cls):
         # AAPL has monthlies
         cls.aapl = web.Options('aapl', 'yahoo')
         today = datetime.today()
@@ -39,8 +37,7 @@ class TestYahooOptions(tm.TestCase):
         cls.data1 = cls.aapl._process_data(cls.aapl._parse_url(cls.json1))
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestYahooOptions, cls).tearDownClass()
+    def teardown_class(cls):
         del cls.aapl, cls.expiry
 
     def assert_option_result(self, df):


### PR DESCRIPTION
Title is self-explanatory.  Now all build machines should not have issues testing due to incompatibilities.