### PR TITLE
TST: Add skip_on_exception decorator

### DIFF
--- a/pandas_datareader/_testing.py
+++ b/pandas_datareader/_testing.py
@@ -1,0 +1,32 @@
+"""
+Utilities for testing purposes.
+"""
+
+from functools import wraps
+
+
+def skip_on_exception(exp):
+    """
+    Skip a test if a specific Exception is raised. This is because
+    the Exception is raised for reasons beyond our control (e.g.
+    flakey 3rd-party API).
+
+    Parameters
+    ----------
+    exp : The Exception under which to execute try-except.
+    """
+
+    from pytest import skip
+
+    def outer_wrapper(f):
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                f(*args, **kwargs)
+            except exp as e:
+                skip(e)
+
+        return wrapper
+
+    return outer_wrapper

--- a/pandas_datareader/tests/google/test_options.py
+++ b/pandas_datareader/tests/google/test_options.py
@@ -8,6 +8,7 @@ import pandas.util.testing as tm
 
 import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestGoogleOptions(object):
@@ -17,12 +18,9 @@ class TestGoogleOptions(object):
         # GOOG has monthlies
         cls.goog = web.Options('GOOG', 'google')
 
+    @skip_on_exception(RemoteDataError)
     def test_get_options_data(self):
-        try:
-            options = self.goog.get_options_data(
-                expiry=self.goog.expiry_dates[0])
-        except RemoteDataError as e:  # pragma: no cover
-            raise pytest.skip(e)
+        options = self.goog.get_options_data(expiry=self.goog.expiry_dates[0])
 
         assert isinstance(options, pd.DataFrame)
         assert len(options) > 10
@@ -48,11 +46,9 @@ class TestGoogleOptions(object):
         with pytest.raises(NotImplementedError):
             self.goog.get_options_data(month=1, year=2016)
 
+    @skip_on_exception(RemoteDataError)
     def test_expiry_dates(self):
-        try:
-            dates = self.goog.expiry_dates
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        dates = self.goog.expiry_dates
 
         assert len(dates) == 2
         assert isinstance(dates, list)

--- a/pandas_datareader/tests/test_edgar.py
+++ b/pandas_datareader/tests/test_edgar.py
@@ -5,6 +5,7 @@ import pandas.util.testing as tm
 import pandas_datareader.data as web
 
 from pandas_datareader._utils import RemoteDataError
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestEdgarIndex(object):
@@ -15,58 +16,47 @@ class TestEdgarIndex(object):
         # Disabling tests until re-write.
         pytest.skip("Disabling tests until re-write.")
 
+    @skip_on_exception(RemoteDataError)
     def test_get_full_index(self):
-        try:
-            ed = web.DataReader('full', 'edgar-index')
-            assert len(ed) > 1000
+        ed = web.DataReader('full', 'edgar-index')
+        assert len(ed) > 1000
 
-            exp_columns = pd.Index(['cik', 'company_name', 'form_type',
-                                    'date_filed', 'filename'], dtype='object')
-            tm.assert_index_equal(ed.columns, exp_columns)
+        exp_columns = pd.Index(['cik', 'company_name', 'form_type',
+                                'date_filed', 'filename'], dtype='object')
+        tm.assert_index_equal(ed.columns, exp_columns)
 
-        except RemoteDataError as e:
-            pytest.skip(e)
-
+    @skip_on_exception(RemoteDataError)
     def test_get_nonzip_index_and_low_date(self):
-        try:
-            ed = web.DataReader('daily', 'edgar-index', '1994-06-30',
-                                '1994-07-02')
-            assert len(ed) > 200
-            assert ed.index.nlevels == 2
+        ed = web.DataReader('daily', 'edgar-index', '1994-06-30',
+                            '1994-07-02')
+        assert len(ed) > 200
+        assert ed.index.nlevels == 2
 
-            dti = ed.index.get_level_values(0)
-            assert isinstance(dti, pd.DatetimeIndex)
-            exp_columns = pd.Index(['company_name', 'form_type',
-                                    'filename'], dtype='object')
-            tm.assert_index_equal(ed.columns, exp_columns)
+        dti = ed.index.get_level_values(0)
+        assert isinstance(dti, pd.DatetimeIndex)
+        exp_columns = pd.Index(['company_name', 'form_type',
+                                'filename'], dtype='object')
+        tm.assert_index_equal(ed.columns, exp_columns)
 
-        except RemoteDataError as e:
-            pytest.skip(e)
-
+    @skip_on_exception(RemoteDataError)
     def test_get_gz_index_and_no_date(self):
         # TODO: Rewrite, as this test causes Travis to timeout.
 
-        try:
-            ed = web.DataReader('daily', 'edgar-index')
-            assert len(ed) > 2000
-        except RemoteDataError as e:
-            pytest.skip(e)
+        ed = web.DataReader('daily', 'edgar-index')
+        assert len(ed) > 2000
 
+    @skip_on_exception(RemoteDataError)
     def test_6_digit_date(self):
-        try:
-            ed = web.DataReader('daily', 'edgar-index', start='1998-05-18',
-                                end='1998-05-18')
-            assert len(ed) < 1200
-            assert ed.index.nlevels == 2
+        ed = web.DataReader('daily', 'edgar-index', start='1998-05-18',
+                            end='1998-05-18')
+        assert len(ed) < 1200
+        assert ed.index.nlevels == 2
 
-            dti = ed.index.get_level_values(0)
-            assert isinstance(dti, pd.DatetimeIndex)
-            assert dti[0] == pd.Timestamp('1998-05-18')
-            assert dti[-1] == pd.Timestamp('1998-05-18')
+        dti = ed.index.get_level_values(0)
+        assert isinstance(dti, pd.DatetimeIndex)
+        assert dti[0] == pd.Timestamp('1998-05-18')
+        assert dti[-1] == pd.Timestamp('1998-05-18')
 
-            exp_columns = pd.Index(['company_name', 'form_type',
-                                    'filename'], dtype='object')
-            tm.assert_index_equal(ed.columns, exp_columns)
-
-        except RemoteDataError as e:
-            pytest.skip(e)
+        exp_columns = pd.Index(['company_name', 'form_type',
+                                'filename'], dtype='object')
+        tm.assert_index_equal(ed.columns, exp_columns)

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -5,6 +5,7 @@ from requests.exceptions import HTTPError
 
 import pandas_datareader as pdr
 import pandas_datareader.data as web
+from pandas_datareader._testing import skip_on_exception
 
 TEST_API_KEY = os.getenv('ENIGMA_API_KEY')
 
@@ -15,21 +16,17 @@ class TestEnigma(object):
     def setup_class(cls):
         pytest.importorskip("lxml")
 
+    @skip_on_exception(HTTPError)
     def test_enigma_datareader(self):
-        try:
-            df = web.DataReader('enigma.inspections.restaurants.fl',
-                                'enigma', access_key=TEST_API_KEY)
-            assert 'serialid' in df.columns
-        except HTTPError as e:  # pragma: no cover
-            pytest.skip(e)
+        df = web.DataReader('enigma.inspections.restaurants.fl',
+                            'enigma', access_key=TEST_API_KEY)
+        assert 'serialid' in df.columns
 
+    @skip_on_exception(HTTPError)
     def test_enigma_get_data_enigma(self):
-        try:
-            df = pdr.get_data_enigma(
-                'enigma.inspections.restaurants.fl', TEST_API_KEY)
-            assert 'serialid' in df.columns
-        except HTTPError as e:  # pragma: no cover
-            pytest.skip(e)
+        df = pdr.get_data_enigma(
+            'enigma.inspections.restaurants.fl', TEST_API_KEY)
+        assert 'serialid' in df.columns
 
     def test_bad_key(self):
         with pytest.raises(HTTPError):

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -3,11 +3,14 @@ import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
 
+from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.compat import assert_raises_regex
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestEurostat(object):
 
+    @skip_on_exception(RemoteDataError)
     def test_get_cdh_e_fos(self):
         # Employed doctorate holders in non managerial and non professional
         # occupations by fields of science (%)
@@ -32,6 +35,7 @@ class TestEurostat(object):
         expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
         tm.assert_frame_equal(df, expected)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_sts_cobp_a(self):
         # Building permits - annual data (2010 = 100)
         df = web.DataReader('sts_cobp_a', 'eurostat',
@@ -64,6 +68,7 @@ class TestEurostat(object):
             result = df[expected.name]
             tm.assert_series_equal(result, expected)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_nrg_pc_202(self):
         # see gh-149
 
@@ -86,6 +91,7 @@ class TestEurostat(object):
 
         tm.assert_series_equal(df[name], exp)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_prc_hicp_manr_exceeds_limit(self):
         # see gh-149
         msg = 'Query size exceeds maximum limit'

--- a/pandas_datareader/tests/test_nasdaq.py
+++ b/pandas_datareader/tests/test_nasdaq.py
@@ -1,15 +1,12 @@
-import pytest
 import pandas_datareader.data as web
 
 from pandas_datareader._utils import RemoteDataError
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestNasdaqSymbols(object):
 
+    @skip_on_exception(RemoteDataError)
     def test_get_symbols(self):
-        try:
-            symbols = web.DataReader('symbols', 'nasdaq')
-        except RemoteDataError as e:
-            pytest.skip(e)
-
+        symbols = web.DataReader('symbols', 'nasdaq')
         assert 'IBM' in symbols.index

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -8,6 +8,7 @@ import requests
 import pandas.util.testing as tm
 from pandas_datareader.wb import (search, download, get_countries,
                                   get_indicators, WorldBankReader)
+from pandas_datareader._testing import skip_on_exception
 from pandas_datareader.compat import assert_raises_regex
 
 
@@ -140,6 +141,7 @@ class TestWB(object):
             assert isinstance(result, pd.DataFrame)
             assert len(result) == 2
 
+    @skip_on_exception(ValueError)
     def test_wdi_download_w_retired_indicator(self):
 
         cntry_codes = ['CA', 'MX', 'US']
@@ -156,32 +158,25 @@ class TestWB(object):
 
         inds = ['GDPPCKD']
 
-        try:
-            result = download(country=cntry_codes, indicator=inds,
-                              start=2003, end=2004, errors='ignore')
-        # If for some reason result actually ever has data, it's cause WB
-        # fixed the issue with this ticker.  Find another bad one.
-        except ValueError as e:
-            pytest.skip("No indicators returned data: {0}".format(e))
+        result = download(country=cntry_codes, indicator=inds,
+                          start=2003, end=2004, errors='ignore')
 
-        # if it ever gets here, it means WB unretired the indicator.
+        # If it ever gets here, it means WB unretired the indicator.
         # even if they dropped it completely, it would still get caught above
         # or the WB API changed somehow in a really unexpected way.
         if len(result) > 0:  # pragma: no cover
             pytest.skip("Invalid results")
 
+    @skip_on_exception(ValueError)
     def test_wdi_download_w_crash_inducing_countrycode(self):
 
         cntry_codes = ['CA', 'MX', 'US', 'XXX']
         inds = ['NY.GDP.PCAP.CD']
 
-        try:
-            result = download(country=cntry_codes, indicator=inds,
-                              start=2003, end=2004, errors='ignore')
-        except ValueError as e:
-            pytest.skip("No indicators returned data: {0}".format(e))
+        result = download(country=cntry_codes, indicator=inds,
+                          start=2003, end=2004, errors='ignore')
 
-        # if it ever gets here, it means the country code XXX got used by WB
+        # If it ever gets here, it means the country code XXX got used by WB
         # or the WB API changed somehow in a really unexpected way.
         if len(result) > 0:  # pragma: no cover
             pytest.skip("Invalid results")

--- a/pandas_datareader/tests/yahoo/test_options.py
+++ b/pandas_datareader/tests/yahoo/test_options.py
@@ -9,6 +9,7 @@ import pandas.util.testing as tm
 
 import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestYahooOptions(object):
@@ -58,6 +59,7 @@ class TestYahooOptions(object):
                    'datetime64[ns]', 'datetime64[ns]', 'object']]
         tm.assert_series_equal(df.dtypes, pd.Series(dtypes, index=exp_columns))
 
+    @skip_on_exception(RemoteDataError)
     def test_get_options_data(self):
         # see gh-6105: regression test
         with pytest.raises(ValueError):
@@ -66,87 +68,64 @@ class TestYahooOptions(object):
         with pytest.raises(ValueError):
             self.aapl.get_options_data(year=1992)
 
-        try:
-            options = self.aapl.get_options_data(expiry=self.expiry)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
-
+        options = self.aapl.get_options_data(expiry=self.expiry)
         self.assert_option_result(options)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_near_stock_price(self):
-        try:
-            options = self.aapl.get_near_stock_price(call=True, put=True,
-                                                     expiry=self.expiry)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
-
+        options = self.aapl.get_near_stock_price(call=True, put=True,
+                                                 expiry=self.expiry)
         self.assert_option_result(options)
 
     def test_options_is_not_none(self):
         option = web.Options('aapl', 'yahoo')
         assert option is not None
 
+    @skip_on_exception(RemoteDataError)
     def test_get_call_data(self):
-        try:
-            calls = self.aapl.get_call_data(expiry=self.expiry)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        calls = self.aapl.get_call_data(expiry=self.expiry)
 
         self.assert_option_result(calls)
         assert calls.index.levels[2][0] == 'call'
 
+    @skip_on_exception(RemoteDataError)
     def test_get_put_data(self):
-        try:
-            puts = self.aapl.get_put_data(expiry=self.expiry)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        puts = self.aapl.get_put_data(expiry=self.expiry)
 
         self.assert_option_result(puts)
         assert puts.index.levels[2][1] == 'put'
 
+    @skip_on_exception(RemoteDataError)
     def test_get_expiry_dates(self):
-        try:
-            dates = self.aapl._get_expiry_dates()
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
-
+        dates = self.aapl._get_expiry_dates()
         assert len(dates) > 1
 
+    @skip_on_exception(RemoteDataError)
     def test_get_all_data(self):
-        try:
-            data = self.aapl.get_all_data(put=True)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        data = self.aapl.get_all_data(put=True)
 
         assert len(data) > 1
         self.assert_option_result(data)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_with_list(self):
-        try:
-            data = self.aapl.get_call_data(expiry=self.aapl.expiry_dates)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        data = self.aapl.get_call_data(expiry=self.aapl.expiry_dates)
 
         assert len(data) > 1
         self.assert_option_result(data)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_all_data_calls_only(self):
-        try:
-            data = self.aapl.get_all_data(call=True, put=False)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        data = self.aapl.get_all_data(call=True, put=False)
 
         assert len(data) > 1
         self.assert_option_result(data)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_underlying_price(self):
         # see gh-7
-
-        try:
-            options_object = web.Options('^spxpm', 'yahoo')
-            quote_price = options_object.underlying_price
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        options_object = web.Options('^spxpm', 'yahoo')
+        quote_price = options_object.underlying_price
 
         assert isinstance(quote_price, float)
 
@@ -186,12 +165,10 @@ class TestYahooOptions(object):
         # Tests that numeric columns with comma's are appropriately dealt with
         assert self.data1['Chg'].dtype == 'float64'
 
+    @skip_on_exception(RemoteDataError)
     def test_month_year(self):
         # see gh-168
-        try:
-            data = self.aapl.get_call_data(month=self.month, year=self.year)
-        except RemoteDataError as e:  # pragma: no cover
-            pytest.skip(e)
+        data = self.aapl.get_call_data(month=self.month, year=self.year)
 
         assert len(data) > 1
         assert data.index.levels[0].dtype == 'float64'


### PR DESCRIPTION
We have tests that might fail for reasons beyond our control. This decorator catches those exceptions and skips those tests when such an error is raised.