### PR TITLE
Replace Yahoo iCharts API

### DIFF
--- a/pandas_datareader/__init__.py
+++ b/pandas_datareader/__init__.py
@@ -1,4 +1,4 @@
-__version__ = version = '0.4.0'
+__version__ = version = '0.4.1'
 
 from .data import (get_components_yahoo, get_data_famafrench, get_data_google, get_data_yahoo, get_data_enigma,  # noqa
         get_data_yahoo_actions, get_quote_google, get_quote_yahoo, DataReader, Options)  # noqa

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -123,7 +123,7 @@ class _BaseReader(object):
             # Increase time between subsequent requests, per subclass.
             pause *= self.pause_multiplier
             # Get a new breadcrumb if necessary, in case ours is invalidated
-            if 'crumb' in params:
+            if isinstance(params, list) and 'crumb' in params:
                 params['crumb'] = self._get_crumb(self.retry_count)
         if params is not None and len(params) > 0:
             url = url + "?" + urlencode(params)

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -99,7 +99,7 @@ class _BaseReader(object):
         """
         return response.content
 
-    def _get_response(self, url, params=None):
+    def _get_response(self, url, params=None, headers=None):
         """ send raw HTTP request to get requests.Response from the specified url
         Parameters
         ----------
@@ -111,7 +111,7 @@ class _BaseReader(object):
 
         # initial attempt + retry
         for i in range(self.retry_count + 1):
-            response = self.session.get(url, params=params)
+            response = self.session.get(url, params=params, headers=headers)
             if response.status_code == requests.codes.ok:
                 return response
             time.sleep(self.pause)
@@ -120,7 +120,7 @@ class _BaseReader(object):
         raise RemoteDataError('Unable to read URL: {0}'.format(url))
 
     def _read_lines(self, out):
-        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]
+        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -87,7 +87,9 @@ class _BaseReader(object):
         text = self._sanitize_response(response)
         out = StringIO()
         if len(text) == 0:
-            raise IOError("Request returned no data.")
+            service = self.__class__.__name__
+            raise IOError("{} request returned no data; check URL for invalid "
+                          "inputs: {}".format(service, self.url))
         if isinstance(text, compat.binary_type):
             out.write(bytes_to_str(text))
         else:

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -136,7 +136,8 @@ class _BaseReader(object):
         raise NotImplementedError("Subclass has not implemented method.")
 
     def _read_lines(self, out):
-        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]
+        rs = read_csv(out, index_col=0, parse_dates=True,
+                      na_values=('-', 'null'))[::-1]
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -120,7 +120,7 @@ class _BaseReader(object):
         raise RemoteDataError('Unable to read URL: {0}'.format(url))
 
     def _read_lines(self, out):
-        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')
+        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -53,6 +53,7 @@ class _BaseReader(object):
         self.retry_count = retry_count
         self.pause = pause
         self.timeout = timeout
+        self.pause_multiplier = 1
         self.session = _init_session(session, retry_count)
 
     @property
@@ -85,6 +86,8 @@ class _BaseReader(object):
         response = self._get_response(url, params=params)
         text = self._sanitize_response(response)
         out = StringIO()
+        if len(text) == 0:
+            raise IOError("Request returned no data.")
         if isinstance(text, compat.binary_type):
             out.write(bytes_to_str(text))
         else:
@@ -110,14 +113,25 @@ class _BaseReader(object):
         """
 
         # initial attempt + retry
+        pause = self.pause
         for i in range(self.retry_count + 1):
             response = self.session.get(url, params=params, headers=headers)
             if response.status_code == requests.codes.ok:
                 return response
-            time.sleep(self.pause)
+            time.sleep(pause)
+
+            # Increase time between subsequent requests, per subclass.
+            pause *= self.pause_multiplier
+            # Get a new breadcrumb if necessary, in case ours is invalidated
+            if 'crumb' in params:
+                params['crumb'] = self._get_crumb(self.retry_count)
         if params is not None and len(params) > 0:
             url = url + "?" + urlencode(params)
         raise RemoteDataError('Unable to read URL: {0}'.format(url))
+
+    def _get_crumb(self, *args):
+        """ To be implemented by subclass """
+        raise NotImplementedError("Subclass has not implemented method.")
 
     def _read_lines(self, out):
         rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -9,7 +9,7 @@ from pandas_datareader.google.quotes import GoogleQuotesReader
 
 from pandas_datareader.yahoo.daily import YahooDailyReader
 from pandas_datareader.yahoo.quotes import YahooQuotesReader
-from pandas_datareader.yahoo.actions import YahooActionReader
+from pandas_datareader.yahoo.actions import (YahooActionReader, YahooDivReader)
 from pandas_datareader.yahoo.components import _get_data as get_components_yahoo  # noqa
 from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.google.options import Options as GoogleOptions
@@ -121,10 +121,10 @@ def DataReader(name, data_source=None, start=None, end=None,
                                  retry_count=retry_count, pause=pause,
                                  session=session).read()
     elif data_source == "yahoo-dividends":
-        return YahooDailyReader(symbols=name, start=start, end=end,
-                                adjust_price=False, chunksize=25,
-                                retry_count=retry_count, pause=pause,
-                                session=session, interval='v').read()
+        return YahooDivReader(symbols=name, start=start, end=end,
+                              adjust_price=False, chunksize=25,
+                              retry_count=retry_count, pause=pause,
+                              session=session, interval='d').read()
 
     elif data_source == "google":
         return GoogleDailyReader(symbols=name, start=start, end=end,

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -127,7 +127,7 @@ class TestYahoo(object):
     def test_get_data_multiple_symbols_two_dates(self):
         pan = web.get_data_yahoo(['GE', 'MSFT', 'INTC'], 'JAN-01-12',
                                  'JAN-31-12')
-        result = pan.Close['01-18-12'].transpose()
+        result = pan.Close['01-18-12'].T
         assert result.size == 3
 
         # sanity checking

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -89,6 +89,7 @@ class TestYahoo(object):
                                  index=['@^NDX'])
             tm.assert_frame_equal(df, expected)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_single_symbol(self):
         # single symbol
         # http://finance.yahoo.com/q/hp?s=GOOG&a=09&b=08&c=2010&d=09&e=10&f=2010&g=d
@@ -219,7 +220,10 @@ class TestYahoo(object):
                            index=exp_idx)
         exp.index.name = 'Date'
 
-        tm.assert_frame_equal(result.sort(axis=1), exp.sort(axis=1))
+        exp = exp.sort_index(axis=1)
+        result = result.sort_index(axis=1)
+
+        tm.assert_frame_equal(result, exp)
 
     @skip_on_exception(RemoteDataError)
     def test_yahoo_DataReader_multi(self):

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -127,17 +127,18 @@ class TestYahoo(object):
     def test_get_data_multiple_symbols_two_dates(self):
         pan = web.get_data_yahoo(['GE', 'MSFT', 'INTC'], 'JAN-01-12',
                                  'JAN-31-12')
-        result = pan.Close.ix['01-18-12']
-        assert len(result) == 3
+        result = pan.Close['01-18-12'].transpose()
+        assert result.size == 3
 
         # sanity checking
-        assert np.issubdtype(result.dtype, np.floating)
+        assert result.dtypes.all() == np.floating
 
         expected = np.array([[18.99, 28.4, 25.18],
                              [18.58, 28.31, 25.13],
                              [19.03, 28.16, 25.52],
                              [18.81, 28.82, 25.87]])
-        result = pan.Open.ix['Jan-15-12':'Jan-20-12']
+        df = pan.Open
+        result = df[(df.index >= 'Jan-15-12') & (df.index <= 'Jan-20-12')]
         assert expected.shape == result.shape
 
     def test_get_date_ret_index(self):
@@ -207,6 +208,8 @@ class TestYahoo(object):
                                       0.47, 0.43571, 0.43571, 0.43571,
                                       0.43571, 0.37857, 0.37857, 0.37857]},
                            index=exp_idx)
+        exp.index.name = 'Date'
+
         tm.assert_frame_equal(result, exp)
 
     def test_yahoo_DataReader_multi(self):

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -10,7 +10,9 @@ import pandas.util.testing as tm
 
 import pandas_datareader.data as web
 from pandas_datareader.data import YahooDailyReader
+from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.yahoo.quotes import _yahoo_codes
+from pandas_datareader._testing import skip_on_exception
 
 
 class TestYahoo(object):
@@ -93,12 +95,14 @@ class TestYahoo(object):
         # just test that we succeed
         web.get_data_yahoo('GOOG')
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_adjust_price(self):
         goog = web.get_data_yahoo('GOOG')
         goog_adj = web.get_data_yahoo('GOOG', adjust_price=True)
         assert 'Adj Close' not in goog_adj.columns
         assert (goog['Open'] * goog_adj['Adj_Ratio']).equals(goog_adj['Open'])
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_interval(self):
         # daily interval data
         pan = web.get_data_yahoo('XOM', '2013-01-01',
@@ -119,11 +123,13 @@ class TestYahoo(object):
         with pytest.raises(ValueError):
             web.get_data_yahoo('XOM', interval='NOT VALID')
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols(self):
         # just test that we succeed
         sl = ['AAPL', 'AMZN', 'GOOG']
         web.get_data_yahoo(sl, '2012')
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols_two_dates(self):
         pan = web.get_data_yahoo(['GE', 'MSFT', 'INTC'], 'JAN-01-12',
                                  'JAN-31-12')
@@ -141,6 +147,7 @@ class TestYahoo(object):
         result = df[(df.index >= 'Jan-15-12') & (df.index <= 'Jan-20-12')]
         assert expected.shape == result.shape
 
+    @skip_on_exception(RemoteDataError)
     def test_get_date_ret_index(self):
         pan = web.get_data_yahoo(['GE', 'INTC', 'IBM'], '1977', '1987',
                                  ret_index=True)
@@ -154,6 +161,7 @@ class TestYahoo(object):
         # sanity checking
         assert np.issubdtype(pan.values.dtype, np.floating)
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_yahoo_actions(self):
         start = datetime(1990, 1, 1)
         end = datetime(2000, 4, 5)
@@ -187,6 +195,7 @@ class TestYahoo(object):
         r = YahooDailyReader('GOOG', session=session)
         assert r.session is session
 
+    @skip_on_exception(RemoteDataError)
     def test_yahoo_DataReader(self):
         start = datetime(2010, 1, 1)
         end = datetime(2015, 5, 9)
@@ -210,8 +219,9 @@ class TestYahoo(object):
                            index=exp_idx)
         exp.index.name = 'Date'
 
-        tm.assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result.sort(axis=1), exp.sort(axis=1))
 
+    @skip_on_exception(RemoteDataError)
     def test_yahoo_DataReader_multi(self):
         start = datetime(2010, 1, 1)
         end = datetime(2015, 5, 9)

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -108,17 +108,12 @@ class TestYahoo(object):
         # weekly interval data
         pan = web.get_data_yahoo('XOM', '2013-01-01',
                                  '2013-12-31', interval='w')
-        assert len(pan) == 53
+        assert len(pan) == 52
 
-        # montly interval data
-        pan = web.get_data_yahoo('XOM', '2013-01-01',
+        # monthly interval data
+        pan = web.get_data_yahoo('XOM', '2012-12-31',
                                  '2013-12-31', interval='m')
         assert len(pan) == 12
-
-        # dividend data
-        pan = web.get_data_yahoo('XOM', '2013-01-01',
-                                 '2013-12-31', interval='v')
-        assert len(pan) == 4
 
         # test fail on invalid interval
         with pytest.raises(ValueError):

--- a/pandas_datareader/yahoo/actions.py
+++ b/pandas_datareader/yahoo/actions.py
@@ -1,4 +1,4 @@
-from pandas import concat
+from pandas import (concat, DataFrame)
 from pandas_datareader.yahoo.daily import YahooDailyReader
 
 
@@ -16,8 +16,9 @@ class YahooActionReader(YahooDailyReader):
                                    pause=self.pause,
                                    session=self.session).read()
         # Add a label column so we can combine our two DFs
-        dividends["action"] = "DIVIDEND"
-        dividends = dividends.rename(columns={'Dividends': 'value'})
+        if isinstance(dividends, DataFrame):
+            dividends["action"] = "DIVIDEND"
+            dividends = dividends.rename(columns={'Dividends': 'value'})
 
         splits = YahooSplitReader(symbols=self.symbols,
                                   start=self.start,
@@ -26,11 +27,12 @@ class YahooActionReader(YahooDailyReader):
                                   pause=self.pause,
                                   session=self.session).read()
         # Add a label column so we can combine our two DFs
-        splits["action"] = "SPLIT"
-        splits = splits.rename(columns={'Stock Splits': 'value'})
-        # Converts fractional form splits (i.e. "2/1") into conversion ratios,
-        # then take the reciprocal
-        splits['value'] = splits.apply(lambda x: 1/eval(x['value']), axis=1)
+        if isinstance(splits, DataFrame):
+            splits["action"] = "SPLIT"
+            splits = splits.rename(columns={'Stock Splits': 'value'})
+            # Converts fractional form splits (i.e. "2/1") into conversion
+            # ratios, then take the reciprocal
+            splits['value'] = splits.apply(lambda x: 1/eval(x['value']), axis=1)  # noqa
 
         output = concat([dividends, splits]).sort_index(ascending=False)
 

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -106,7 +106,7 @@ class YahooDailyReader(_DailyBaseReader):
                                       params=self.params, headers=self.headers)
         out = str(self._sanitize_response(response))
         # Matches: {"crumb":"AlphaNumeric"}
-        regex = re.search(r'{"crumb" ?: ?"([A-Za-z0-9.]{11,})"}', out)
+        regex = re.search(r'"crumb" ?: ?"([A-Za-z0-9.]{11,})"', out)
 
         try:
             crumbs = regex.groups()

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -154,19 +154,10 @@ class YahooDailyReader(_DailyBaseReader):
                                       params=self.params, headers=self.headers)
         out = str(self._sanitize_response(response))
         # Matches: {"crumb":"AlphaNumeric"}
-        regex = re.search(r'"crumb" ?: ?"([A-Za-z0-9.\\]{11,})"', out)
+        rpat = '"CrumbStore":{"crumb":"([^"]+)"}'
 
-        if regex is not None:
-            crumbs = regex.groups()
-            crumb = re.sub(r'\\', '', crumbs[0])
-            return crumb
-        elif retries > 0:
-            # It is possible we hit a 401 with frequent requests. Cool-off:
-            time.sleep(2)
-            retries -= 1
-            return self._get_crumb(retries)
-        else:
-            raise OSError("Unable to retrieve Yahoo breadcrumb, exiting.")
+        crumb = re.findall(rpat, out)[0]
+        return crumb.encode('ascii').decode('unicode-escape')
 
 
 def _adjust_prices(hist_data, price_list=None):

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -61,9 +61,9 @@ class YahooDailyReader(_DailyBaseReader):
         self.adjust_price = adjust_price
         self.ret_index = ret_index
 
-        if interval not in ['d', 'w', 'm', 'v']:
+        if interval not in ['d', 'w', 'm']:
             raise ValueError("Invalid interval: valid values are "
-                             "'d', 'w', 'm' and 'v'")
+                             "'d', 'w', 'm'")
         self.interval = '1' + interval
         # self.crumb = '64ZkTeri7Xq'
         self.crumb = self._get_crumb(retry_count)

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -45,13 +45,16 @@ class YahooDailyReader(_DailyBaseReader):
     """
 
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
-                 pause=0.001, session=None, adjust_price=False,
+                 pause=0.35, session=None, adjust_price=False,
                  ret_index=False, chunksize=25, interval='d'):
         super(YahooDailyReader, self).__init__(symbols=symbols,
                                                start=start, end=end,
                                                retry_count=retry_count,
                                                pause=pause, session=session,
                                                chunksize=chunksize)
+        # Ladder up the wait time between subsequent requests to improve
+        # probability of a successful retry
+        self.pause_multiplier = 2.5
 
         self.headers = {
             'Connection': 'keep-alive',

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -69,6 +69,10 @@ class YahooDailyReader(_DailyBaseReader):
         self.crumb = self._get_crumb(retry_count)
 
     @property
+    def service(self):
+        return 'history'
+
+    @property
     def url(self):
         return 'https://query1.finance.yahoo.com/v7/finance/download/{}'.format(self.symbols)  # noqa
 
@@ -80,7 +84,7 @@ class YahooDailyReader(_DailyBaseReader):
             'period1': unix_start,
             'period2': unix_end,
             'interval': self.interval,
-            'events': 'history',
+            'events': self.service,
             'crumb': self.crumb
         }
         return params
@@ -93,7 +97,7 @@ class YahooDailyReader(_DailyBaseReader):
         if self.adjust_price:
             df = _adjust_prices(df)
         temp = pd.date_range(self.start, self.end, None, self.interval)
-        return df
+        return df.sort_index()
 
     def _get_crumb(self, retries):
         # Scrape a history page for a valid crumb ID:


### PR DESCRIPTION
Based on multiple issues raised with this and similar libraries, it appears that Yahoo's iCharts API is being phased out. The new API requires a cookie and updated URL/parameter structure, implemented by this PR. See:

- [Issues with the data reader fetching yahoo finance #315](https://github.com/pydata/pandas-datareader/issues/315)
- [Recent failure in 0.4 #330](https://github.com/pydata/pandas-datareader/issues/330)

This will fix standard pulls for interval prices for a single stock, but not yet for multiple stocks - if the maintainers agree with the approach I can continue to debug and build this out, otherwise we can scrap it.