### PR TITLE
Added Stooq Remote Data for Major Indexes 

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -34,6 +34,8 @@ Currently the following sources are supported:
     - :ref:`Thrift Savings Plan<remote_data.tsp>`
     - :ref:`Oanda currency historical rate<remote_data.oanda_curr_hist>`
     - :ref:`Nasdaq Trader symbol definitions<remote_data.nasdaq_symbols`
+    - :ref:`Stooq<remote_data.stooq>`
+
 
 It should be noted, that various sources support different kinds of data, so not all sources implement the same methods and the data elements returned might also differ.
 
@@ -574,3 +576,14 @@ available. More information on the `field<http://www.nasdaqtrader.com/trader.asp
         Name: IBM, dtype: object
 
 
+.. _remote_data.stooq:
+
+Stooq Index Data
+================
+Google finance doesn't provide common index data download. The Stooq site has the data for download. 
+
+.. ipython:: python
+
+    import pandas_datareader.data as web
+    f = web.DataReader("^DJI", 'stooq')
+    f[:10]

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -4,6 +4,7 @@ Module contains tools for collecting data from various remote sources
 
 import warnings
 
+from pandas_datareader.stooq import StooqDailyReader
 from pandas_datareader.google.daily import GoogleDailyReader
 from pandas_datareader.google.quotes import GoogleQuotesReader
 
@@ -128,6 +129,12 @@ def DataReader(name, data_source=None, start=None, end=None,
 
     elif data_source == "google":
         return GoogleDailyReader(symbols=name, start=start, end=end,
+                                 chunksize=25,
+                                 retry_count=retry_count, pause=pause,
+                                 session=session).read()
+
+    elif data_source == "stooq":
+        return StooqDailyReader(symbols=name,
                                  chunksize=25,
                                  retry_count=retry_count, pause=pause,
                                  session=session).read()

--- a/pandas_datareader/stooq.py
+++ b/pandas_datareader/stooq.py
@@ -1,0 +1,36 @@
+from pandas_datareader.base import _DailyBaseReader
+
+
+class StooqDailyReader(_DailyBaseReader):
+
+    """
+    Returns DataFrame/Panel of historical stock prices from symbols, over date
+    range, start to end. To avoid being penalized by Google Finance servers,
+    pauses between downloading 'chunks' of symbols can be specified.
+
+    Parameters
+    ----------
+    symbols : string, array-like object (list, tuple, Series), or DataFrame
+        Single stock symbol (ticker), array-like object of symbols or
+        DataFrame with index containing stock symbols.
+    retry_count : int, default 3
+        Number of times to retry query request.
+    pause : int, default 0
+        Time, in seconds, to pause between consecutive queries of chunks. If
+        single value given for symbol, represents the pause between retries.
+    chunksize : int, default 25
+        Number of symbols to download consecutively before intiating pause.
+    session : Session, default None
+        requests.sessions.Session instance to be used
+    """
+
+    @property
+    def url(self):
+        return 'https://stooq.com/q/d/l/'
+
+    def _get_params(self, symbol):
+        params = {
+            's': symbol,
+            'i': "d"
+        }
+        return params


### PR DESCRIPTION
Google finance doesn't provide common indexes' historical prices downloading. The Stooq site has the data.  Kindly request review on those changes. 
