### PR TITLE
fix 'null' in lower case as a  missing value in the new Yahoo API, make compatible with the older pandas versions

### DIFF
--- a/docs/source/whatsnew/v0.5.0.txt
+++ b/docs/source/whatsnew/v0.5.0.txt
@@ -23,3 +23,4 @@ Bug Fixes
 - Test suite fixes for test_get_options_data (:issue:`352`)
 - Test suite fixes for test_wdi_download (:issue:`350`)
 - avoid monkey patching requests.Session (:issue:`301`)
+- :func:`get_data_yahoo` now treats ``'null'`` strings as missing values  (:issue:`342`)

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -143,7 +143,7 @@ class _BaseReader(object):
         raise NotImplementedError("Subclass has not implemented method.")
 
     def _read_lines(self, out):
-        rs = read_csv(out, index_col=0, parse_dates=True, na_values='-')[::-1]
+        rs = read_csv(out, index_col=0, parse_dates=True, na_values=('-', 'null'))[::-1]
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -143,7 +143,8 @@ class _BaseReader(object):
         raise NotImplementedError("Subclass has not implemented method.")
 
     def _read_lines(self, out):
-        rs = read_csv(out, index_col=0, parse_dates=True, na_values=('-', 'null'))[::-1]
+        rs = read_csv(out, index_col=0, parse_dates=True,
+                      na_values=('-','null'))[::-1]
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -144,7 +144,7 @@ class _BaseReader(object):
 
     def _read_lines(self, out):
         rs = read_csv(out, index_col=0, parse_dates=True,
-                      na_values=('-','null'))[::-1]
+                      na_values=('-', 'null'))[::-1]
         # Yahoo! Finance sometimes does this awesome thing where they
         # return 2 rows for the most recent business day
         if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -133,8 +133,8 @@ class TestYahoo(object):
 
     @pytest.mark.parametrize('adj_pr', [True, False])
     def test_get_data_null_as_missing_data(self, adj_pr):
-        # workaround as skip_on_exception decorator changes signature
-        # TODO: should it be changed to a signature-preserving decorator?
+        # TODO: We can't decorate the test function along with
+        # parametrization because it errors.  Investigate this later.
         @skip_on_exception(RemoteDataError)
         def null_as_missing_data(adj_price):
             result = web.get_data_yahoo('SRCE', '20160626', '20160705',

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -134,7 +134,7 @@ class TestYahoo(object):
     @pytest.mark.parametrize('adj_pr', [True, False])
     def test_get_data_null_as_missing_data(self, adj_pr):
         # workaround as skip_on_exception decorator changes signature
-        # should it be changed to a signature-preserving decorator?
+        # TODO: should it be changed to a signature-preserving decorator?
         @skip_on_exception(RemoteDataError)
         def null_as_missing_data(adj_price):
             result = web.get_data_yahoo('SRCE', '20160626', '20160705',

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -132,6 +132,11 @@ class TestYahoo(object):
         web.get_data_yahoo(sl, '2012')
 
     @skip_on_exception(RemoteDataError)
+    def test_get_data_null_as_missing_data(self):
+        # just test that we succeed
+        web.get_data_yahoo('SRCE', '20160626', '20160705', adjust_price=True)
+
+    @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols_two_dates(self):
         pan = web.get_data_yahoo(['GE', 'MSFT', 'INTC'], 'JAN-01-12',
                                  'JAN-31-12')

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -131,17 +131,18 @@ class TestYahoo(object):
         sl = ['AAPL', 'AMZN', 'GOOG']
         web.get_data_yahoo(sl, '2012')
 
-    @skip_on_exception(RemoteDataError)
-    def test_get_data_null_as_missing_data_no_adjust(self):
-        result = web.get_data_yahoo('SRCE', '20160626', '20160705',
-                                    adjust_price=False)
-        # sanity checking
-        assert result.dtypes.all() == np.floating
+    @pytest.mark.parametrize('adj_pr', [True, False])
+    def test_get_data_null_as_missing_data(self, adj_pr):
+        #workaround as skip_on_exception decorator changes signature
+        # should it be changed to a signature-preserving decorator?
+        @skip_on_exception(RemoteDataError)
+        def null_as_missing_data(adj_price):
+            result = web.get_data_yahoo('SRCE', '20160626', '20160705',
+                                        adjust_price=adj_pr)
+            # sanity checking
+            assert result.dtypes.all() == np.floating
 
-    @skip_on_exception(RemoteDataError)
-    def test_get_data_null_as_missing_data_adjust(self):
-        # just test that we succeed
-        web.get_data_yahoo('SRCE', '20160626', '20160705', adjust_price=True)
+        null_as_missing_data(adj_pr)
 
     @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols_two_dates(self):

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -133,7 +133,6 @@ class TestYahoo(object):
 
     @skip_on_exception(RemoteDataError)
     def test_get_data_null_as_missing_data_no_adjust(self):
-        # just test that we succeed
         result = web.get_data_yahoo('SRCE', '20160626', '20160705',
                                     adjust_price=False)
         # sanity checking

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -131,6 +131,7 @@ class TestYahoo(object):
         sl = ['AAPL', 'AMZN', 'GOOG']
         web.get_data_yahoo(sl, '2012')
 
+    @skip_on_exception(RemoteDataError)
     def test_get_data_null_as_missing_data_no_adjust(self):
         # just test that we succeed
         result = web.get_data_yahoo('SRCE', '20160626', '20160705',

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -133,7 +133,8 @@ class TestYahoo(object):
 
     def test_get_data_null_as_missing_data_no_adjust(self):
         # just test that we succeed
-        result = web.get_data_yahoo('SRCE', '20160626', '20160705', adjust_price=False)
+        result = web.get_data_yahoo('SRCE', '20160626', '20160705',
+                                    adjust_price=False)
         # sanity checking
         assert result.dtypes.all() == np.floating
 

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -133,7 +133,7 @@ class TestYahoo(object):
 
     @pytest.mark.parametrize('adj_pr', [True, False])
     def test_get_data_null_as_missing_data(self, adj_pr):
-        #workaround as skip_on_exception decorator changes signature
+        # workaround as skip_on_exception decorator changes signature
         # should it be changed to a signature-preserving decorator?
         @skip_on_exception(RemoteDataError)
         def null_as_missing_data(adj_price):

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -131,8 +131,14 @@ class TestYahoo(object):
         sl = ['AAPL', 'AMZN', 'GOOG']
         web.get_data_yahoo(sl, '2012')
 
+    def test_get_data_null_as_missing_data_no_adjust(self):
+        # just test that we succeed
+        result = web.get_data_yahoo('SRCE', '20160626', '20160705', adjust_price=False)
+        # sanity checking
+        assert result.dtypes.all() == np.floating
+
     @skip_on_exception(RemoteDataError)
-    def test_get_data_null_as_missing_data(self):
+    def test_get_data_null_as_missing_data_adjust(self):
         # just test that we succeed
         web.get_data_yahoo('SRCE', '20160626', '20160705', adjust_price=True)
 


### PR DESCRIPTION
closes #342
 
add 'null' in lower case to na_values argument to read_csv