### PR TITLE
Fix deprecation

### DIFF
--- a/pandas_datareader/fred.py
+++ b/pandas_datareader/fred.py
@@ -1,4 +1,4 @@
-from pandas.core.common import is_list_like
+from pandas.api.types import is_list_like
 from pandas import concat, read_csv
 
 from pandas_datareader.base import _BaseReader


### PR DESCRIPTION
Fix message when using pandas 0.20.3:

\fred.py:24: DeprecationWarning: pandas.core.common.is_list_like is deprecated. import from the public API: pandas.api.types.is_list_like instead