### PR TITLE
TST: Update pandas to minimum 0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,22 @@ matrix:
   include:
   - dist: trusty
     env:
-      - PYTHON=2.7 PANDAS=0.17.1
-  - dist: trusty
-    env:
       - PYTHON=2.7 PANDAS=0.19.2
   - dist: trusty
     env:
-      - PYTHON=3.5 PANDAS=0.17.1
+      - PYTHON=2.7 PANDAS=0.22
   - dist: trusty
     env:
-      - PYTHON=3.5 PANDAS=0.18.1
+      - PYTHON=3.5 PANDAS=0.19.2
   - dist: trusty
     env:
-      - PYTHON=3.6 PANDAS=0.19.2
+      - PYTHON=3.5 PANDAS=0.20.3
   - dist: trusty
     env:
-      - PYTHON=3.6 PANDAS=0.20.2
+      - PYTHON=3.6 PANDAS=0.21.1
+  - dist: trusty
+    env:
+      - PYTHON=3.6 PANDAS=0.22
   # In allow failures
   - dist: trusty
     env:


### PR DESCRIPTION
Update pandas to use 0.19 as the minimum version

Maintenance only. 