### PR TITLE
CLN/REF: Mark deprecated API

### DIFF
--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -8,6 +8,8 @@ from pandas_datareader.bankofcanada import BankOfCanadaReader
 from pandas_datareader.edgar import EdgarIndexReader
 from pandas_datareader.enigma import EnigmaReader
 from pandas_datareader.eurostat import EurostatReader
+from pandas_datareader.exceptions import ImmediateDeprecationError, \
+    DEP_ERROR_MSG
 from pandas_datareader.famafrench import FamaFrenchReader
 from pandas_datareader.fred import FredReader
 from pandas_datareader.google.daily import GoogleDailyReader
@@ -51,6 +53,7 @@ def get_data_google(*args, **kwargs):
 
 
 def get_data_yahoo(*args, **kwargs):
+    raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Actions'))
     return YahooDailyReader(*args, **kwargs).read()
 
 
@@ -59,14 +62,17 @@ def get_data_enigma(*args, **kwargs):
 
 
 def get_data_yahoo_actions(*args, **kwargs):
+    raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Actions'))
     return YahooActionReader(*args, **kwargs).read()
 
 
 def get_quote_yahoo(*args, **kwargs):
+    raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Actions'))
     return YahooQuotesReader(*args, **kwargs).read()
 
 
 def get_quote_google(*args, **kwargs):
+    raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Google Quotes'))
     return GoogleQuotesReader(*args, **kwargs).read()
 
 
@@ -210,17 +216,16 @@ def DataReader(name, data_source=None, start=None, end=None,
     """
     Imports data from a number of online sources.
 
-    Currently supports Yahoo! Finance, Google Finance, St. Louis FED (FRED),
-    Kenneth French's data library, and the SEC's EDGAR Index.
+    Currently supports Google Finance, St. Louis FED (FRED),
+    and Kenneth French's data library, among others.
 
     Parameters
     ----------
     name : str or list of strs
-        the name of the dataset. Some data sources (yahoo, google, fred) will
+        the name of the dataset. Some data sources (google, fred) will
         accept a list of names.
     data_source: {str, None}
-        the data source ("yahoo", "yahoo-actions", "yahoo-dividends",
-        "google", "fred", "ff", or "edgar-index")
+        the data source ("google", "fred", "ff")
     start : {datetime, None}
         left boundary for range (defaults to 1/1/2010)
     end : {datetime, None}
@@ -237,14 +242,6 @@ def DataReader(name, data_source=None, start=None, end=None,
 
     Examples
     ----------
-
-    # Data from Yahoo! Finance
-    gs = DataReader("GS", "yahoo")
-
-    # Corporate Actions (Dividend and Split Data)
-    # with ex-dates from Yahoo! Finance
-    gs = DataReader("GS", "yahoo-actions")
-
     # Data from Google Finance
     aapl = DataReader("AAPL", "google")
 
@@ -263,23 +260,23 @@ def DataReader(name, data_source=None, start=None, end=None,
     ff = DataReader("F-F_Research_Data_Factors_weekly", "famafrench")
     ff = DataReader("6_Portfolios_2x3", "famafrench")
     ff = DataReader("F-F_ST_Reversal_Factor", "famafrench")
-
-    # Data from EDGAR index
-    ed = DataReader("full", "edgar-index")
-    ed2 = DataReader("daily", "edgar-index")
     """
     if data_source == "yahoo":
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Daily'))
         return YahooDailyReader(symbols=name, start=start, end=end,
                                 adjust_price=False, chunksize=25,
                                 retry_count=retry_count, pause=pause,
                                 session=session).read()
 
     elif data_source == "yahoo-actions":
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Actions'))
         return YahooActionReader(symbols=name, start=start, end=end,
                                  retry_count=retry_count, pause=pause,
                                  session=session).read()
 
     elif data_source == "yahoo-dividends":
+        comp = 'Yahoo Dividends'
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format(comp))
         return YahooDivReader(symbols=name, start=start, end=end,
                               adjust_price=False, chunksize=25,
                               retry_count=retry_count, pause=pause,
@@ -337,6 +334,7 @@ def DataReader(name, data_source=None, start=None, end=None,
                               retry_count=retry_count, pause=pause,
                               session=session).read()
     elif data_source == "edgar-index":
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('EDGAR'))
         return EdgarIndexReader(symbols=name, start=start, end=end,
                                 retry_count=retry_count, pause=pause,
                                 session=session).read()
@@ -364,8 +362,10 @@ def Options(symbol, data_source=None, session=None):
                       " data_source) instead", FutureWarning, stacklevel=2)
         data_source = "yahoo"
     if data_source == "yahoo":
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Options'))
         return YahooOptions(symbol, session=session)
     elif data_source == "google":
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Google Options'))
         return GoogleOptions(symbol, session=session)
     else:
         raise NotImplementedError("currently only yahoo and google supported")

--- a/pandas_datareader/exceptions.py
+++ b/pandas_datareader/exceptions.py
@@ -3,3 +3,16 @@
 
 class UnstableAPIWarning(Warning):
     pass
+
+
+DEP_ERROR_MSG = """
+{0} has been immediately deprecated due to large breaks in the API without the
+introduction of a stable replacement. Pull Requests to re-enable these data
+connectors are welcome.
+
+See https://github.com/pydata/pandas-datareader/issues
+"""
+
+
+class ImmediateDeprecationError(Exception):
+    pass

--- a/pandas_datareader/google/daily.py
+++ b/pandas_datareader/google/daily.py
@@ -1,8 +1,13 @@
 from pandas_datareader.base import _DailyBaseReader
+from pandas_datareader.exceptions import UnstableAPIWarning
+
+UNSTABLE_WARNING = """
+The Google Finance API has not been stable since late 2017. Requests seem
+to fail at random. Failure is especially common when bulk downloading.
+"""
 
 
 class GoogleDailyReader(_DailyBaseReader):
-
     """
     Returns DataFrame/Panel of historical stock prices from symbols, over date
     range, start to end. To avoid being penalized by Google Finance servers,
@@ -28,6 +33,14 @@ class GoogleDailyReader(_DailyBaseReader):
     session : Session, default None
         requests.sessions.Session instance to be used
     """
+
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None, chunksize=25):
+        import warnings
+        warnings.warn(UNSTABLE_WARNING, UnstableAPIWarning)
+        super(GoogleDailyReader, self).__init__(symbols, start, end,
+                                                retry_count, pause, session,
+                                                chunksize)
 
     @property
     def url(self):

--- a/pandas_datareader/tests/google/test_options.py
+++ b/pandas_datareader/tests/google/test_options.py
@@ -1,20 +1,23 @@
-import pytest
-
 from datetime import date
 
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 
 import pandas_datareader.data as web
+from pandas_datareader.exceptions import ImmediateDeprecationError
 
 
 class TestGoogleOptions(object):
 
     @classmethod
     def setup_class(cls):
-        # GOOG has monthlies
-        cls.goog = web.Options('GOOG', 'google')
+        cls.goog = None
+
+    def test_deprecation(self):
+        with pytest.raises(ImmediateDeprecationError):
+            web.Options('GOOG', 'google')
 
     @pytest.mark.xfail(reason='Parsing error')
     def test_get_options_data(self):
@@ -40,8 +43,9 @@ class TestGoogleOptions(object):
         for typ in options.index.levels[2]:
             assert typ in ['put', 'call']
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_options_data_yearmonth(self):
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ImmediateDeprecationError):
             self.goog.get_options_data(month=1, year=2016)
 
     @pytest.mark.xfail(reason='Parsing error')
@@ -52,26 +56,32 @@ class TestGoogleOptions(object):
         assert isinstance(dates, list)
         assert all(isinstance(dt, date) for dt in dates)
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_call_data(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_call_data()
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_put_data(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_put_data()
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_near_stock_price(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_near_stock_price()
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_forward_data(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_forward_data([1, 2, 3])
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_all_data(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_all_data()
 
+    @pytest.mark.xfail(reason='Deprecated')
     def test_get_options_data_with_year(self):
         with pytest.raises(NotImplementedError):
             self.goog.get_options_data(year=2016)

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -1,17 +1,7 @@
 import pytest
 
-import pandas.util.testing as tm
-import pandas_datareader.data as web
-
 from pandas import DataFrame
 from pandas_datareader.data import DataReader
-
-
-class TestOptionsWarnings(object):
-
-    def test_options_source_warning(self):
-        with tm.assert_produces_warning():
-            web.Options('aapl')
 
 
 class TestDataReader(object):

--- a/pandas_datareader/tests/test_edgar.py
+++ b/pandas_datareader/tests/test_edgar.py
@@ -1,8 +1,9 @@
-import pytest
-
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
+
 import pandas_datareader.data as web
+from pandas_datareader.exceptions import ImmediateDeprecationError
 
 
 class TestEdgarIndex(object):
@@ -12,6 +13,10 @@ class TestEdgarIndex(object):
         # As of December 31, SEC has disabled ftp access to EDGAR.
         # Disabling tests until re-write.
         pytest.skip("Disabling tests until re-write.")
+
+    def test_raises(self):
+        with pytest.raises(ImmediateDeprecationError):
+            web.DataReader('full', 'edgar-index')
 
     def test_get_full_index(self):
         ed = web.DataReader('full', 'edgar-index')

--- a/pandas_datareader/yahoo/components.py
+++ b/pandas_datareader/yahoo/components.py
@@ -1,6 +1,9 @@
 from pandas import DataFrame
 from pandas.io.common import urlopen
 
+from pandas_datareader.exceptions import ImmediateDeprecationError, \
+    DEP_ERROR_MSG
+
 _URL = 'http://download.finance.yahoo.com/d/quotes.csv?'
 
 
@@ -25,6 +28,7 @@ def _get_data(idx_sym):  # pragma: no cover
     -------
     idx_df : DataFrame
     """
+    raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Yahoo Components'))
     stats = 'snx'
     # URL of form:
     # http://download.finance.yahoo.com/d/quotes.csv?s=@%5EIXIC&f=snxl1d1t1c1ohgv


### PR DESCRIPTION
Add immediate deprecation errors to Yahoo, Google Options and Quotes,
and EDGAR
Add warning to Google finance

- [x] closes #439
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
