### PR TITLE
TST: Improve coverage reporting accuracy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -26,7 +26,9 @@ include = */pandas_datareader/*
 omit =
     */_version.py
     */yahoo/*
+    */edgar.py
     */google/options.py
     */google/quotes.py
     */tests/google/test_options.py
+    */tests/test_edgar.py
 ignore_errors = True


### PR DESCRIPTION
Skip edgar in coverage

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

