### PR TITLE
BUG: Add API KEY for Quandl

### DIFF
--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -1,0 +1,30 @@
+.. _whatsnew_070:
+
+v0.7.0 (Xxxxxxx YY, 20ZZ)
+---------------------------
+
+
+Highlights include:
+
+
+.. contents:: What's new in v0.7.0
+    :local:
+    :backlinks: none
+
+.. _whatsnew_070.enhancements:
+
+Enhancements
+~~~~~~~~~~~~
+
+.. _whatsnew_070.api_breaking:
+
+Backwards incompatible API changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _whatsnew_070.bug_fixes:
+
+Bug Fixes
+~~~~~~~~~
+
+- Added support for passing the API KEY to QuandlReader either directly or by
+  setting the environmental variable QUANDL_API_KEY (:issue:`485`).

--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -17,8 +17,10 @@ PANDAS_0210 = (PANDAS_VERSION >= LooseVersion('0.21.0'))
 
 if PANDAS_0190:
     from pandas.api.types import is_number
+    from pandas.util.testing import assert_frame_equal
 else:
     from pandas.core.common import is_number
+    from pandas.testing import assert_frame_equal
 
 if PANDAS_0200:
     from pandas.util.testing import assert_raises_regex

--- a/pandas_datareader/tests/test_quandl.py
+++ b/pandas_datareader/tests/test_quandl.py
@@ -1,6 +1,13 @@
+import os
+
+import pytest
+
 import pandas_datareader.data as web
-from pandas_datareader._utils import RemoteDataError
-from pandas_datareader._testing import skip_on_exception
+from pandas_datareader.compat import assert_frame_equal
+
+TEST_API_KEY = os.getenv('QUANDL_API_KEY')
+# Ensure blank TEST_API_KEY not used in pull request
+TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 
 
 class TestQuandl(object):
@@ -17,76 +24,88 @@ class TestQuandl(object):
         act_cols = frozenset(df.columns.tolist())
         assert expected_cols == act_cols, "unexpected cols: " + str(act_cols)
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_wiki_us(self):
-        df = web.DataReader('F', 'quandl', self.start10, self.end10)
+        df = web.DataReader('F', 'quandl', self.start10, self.end10,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, ['Open', 'High', 'Low', 'Close', 'Volume',
                                 'ExDividend', 'SplitRatio', 'AdjOpen',
                                 'AdjHigh', 'AdjLow', 'AdjClose', 'AdjVolume'])
         assert df.Close.at[self.day10] == 7.70
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_fse_frankfurt(self):
         # ALV_X: Allianz SE
-        df = web.DataReader('FSE/ALV_X', 'quandl', self.start10, self.end10)
+        df = web.DataReader('FSE/ALV_X', 'quandl', self.start10, self.end10,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, ['Open', 'High', 'Low', 'Close', 'Change',
                                 'TradedVolume', 'Turnover',
                                 'LastPriceoftheDay', 'DailyTradedUnits',
                                 'DailyTurnover'])
         assert df.Close.at[self.day10] == 159.45
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_sse_de_stuttgart(self):
         # ALV: Allianz SE
-        df = web.DataReader('SSE/ALV', 'quandl', self.start2, self.end2)
+        df = web.DataReader('SSE/ALV', 'quandl', self.start2, self.end2,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, [
-                "High", "Low", "Last", "PreviousDayPrice", "Volume"])
+            "High", "Low", "Last", "PreviousDayPrice", "Volume"])
         # as of 2017-06-11: PreviousDayPrice can be outside Low/High range;
         # Volume can be NaN
         assert df.Last.at[self.day2] == 136.47
         df2 = web.DataReader('ALV.DE', 'quandl', self.start2, self.end2)
         assert (df.Last == df2.Last).all()
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_euronext_be_fr_nl_pt(self):
         # FP: Total SA
         # as of 2017-06-11, some datasets end a few months after their start,
         # e.g. ALVD, BASD
-        df = web.DataReader('EURONEXT/FP', 'quandl', self.start2, self.end2)
+        df = web.DataReader('EURONEXT/FP', 'quandl', self.start2, self.end2,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, [
-                "Open", "High", "Low", "Last", "Turnover", "Volume"])
+            "Open", "High", "Low", "Last", "Turnover", "Volume"])
         assert df.Last.at[self.day2] == 42.525
         df2 = web.DataReader('FP.FR', 'quandl', self.start2, self.end2)
         assert (df.Last == df2.Last).all()
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_lse_uk(self):
         # RBS: Royal Bank of Scotland
-        df = web.DataReader('LSE/RBS', 'quandl', self.start10, self.end10)
+        df = web.DataReader('LSE/RBS', 'quandl', self.start10, self.end10,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, ["High", "Low", "LastClose", "Price",
                                 "Volume", "Change", "Var"])
         # as of 2017-06-11, Price == LastClose, all others are NaN
         assert df.Price.at[self.day10] == 5950.983
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_nse_in(self):
         # TCS: Tata Consutancy Services
-        df = web.DataReader('NSE/TCS', 'quandl', self.start10, self.end10)
+        df = web.DataReader('NSE/TCS', 'quandl', self.start10, self.end10,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, ['Open', 'High', 'Low', 'Last', 'Close',
                                 'TotalTradeQuantity', 'TurnoverLacs'])
         assert df.Close.at[self.day10] == 1259.05
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_tse_jp(self):
         # TSE/6758: Sony Corp.
-        df = web.DataReader('TSE/6758', 'quandl', self.start10, self.end10)
+        df = web.DataReader('TSE/6758', 'quandl', self.start10, self.end10,
+                            access_key=TEST_API_KEY)
         self.check_headers(df, ['Open', 'High', 'Low', 'Close', 'Volume'])
         assert df.Close.at[self.day10] == 5190.0
 
-    @skip_on_exception(RemoteDataError)
+        df2 = web.get_data_quandl('TSE/6758', self.start10, self.end10,
+                                  api_key=TEST_API_KEY)
+        assert_frame_equal(df, df2)
+
+    @pytest.mark.skipif(TEST_API_KEY is None, reason="QUANDL_API_KEY not set")
     def test_db_hkex_cn(self):
         # HKEX/00941: China Mobile
-        df = web.DataReader('HKEX/00941', 'quandl', self.start2, self.end2)
+        df = web.DataReader('HKEX/00941', 'quandl', self.start2, self.end2,
+                            access_key=TEST_API_KEY)
         self.check_headers(df,
                            ['NominalPrice', 'NetChange', 'Change', 'Bid',
                             'Ask', 'PEx', 'High', 'Low', 'PreviousClose',


### PR DESCRIPTION
Add support for the Quandl API key

closes #484

- [X] closes #484
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
