### PR TITLE
Repaired Morningstar volume for indicies

### DIFF
--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -28,3 +28,4 @@ Bug Fixes
 
 - Added support for passing the API KEY to QuandlReader either directly or by
   setting the environmental variable QUANDL_API_KEY (:issue:`485`).
+- Handle Morningstar index volume data properly (:issue:`486`).

--- a/pandas_datareader/mstar/daily.py
+++ b/pandas_datareader/mstar/daily.py
@@ -165,7 +165,7 @@ class MorningstarDailyReader(_BaseReader):
         if jsondata["VolumeList"]:
             volumes = jsondata["VolumeList"]["Datapoints"]
         else:
-            volumes = [np.nan] * 1000000
+            volumes = None
 
         dates = self._convert_index2date(indexvals=dateidx)
         barss = []
@@ -196,10 +196,10 @@ class MorningstarDailyReader(_BaseReader):
                     else:
                         pass
             if self.incl_vol is True:
-                try:
+                if volumes is None:
+                    bardict.update({"Volume": np.nan})
+                else:
                     bardict.update({"Volume": int(volumes[p] * 1000000)})
-                except ValueError:
-                    bardict.update({"Volume": volumes[p]})
             else:
                 pass
 

--- a/pandas_datareader/mstar/daily.py
+++ b/pandas_datareader/mstar/daily.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 import requests
 from pandas import DataFrame
+import numpy as np
 
 from pandas_datareader._utils import SymbolWarning
 from pandas_datareader.base import _BaseReader
@@ -161,7 +162,10 @@ class MorningstarDailyReader(_BaseReader):
 
         pricedata = jsondata["PriceDataList"][0]["Datapoints"]
         dateidx = jsondata["PriceDataList"][0]["DateIndexs"]
-        volumes = jsondata["VolumeList"]["Datapoints"]
+        if jsondata["VolumeList"]:
+            volumes = jsondata["VolumeList"]["Datapoints"]
+        else:
+            volumes = [np.nan] * 1000000
 
         dates = self._convert_index2date(indexvals=dateidx)
         barss = []
@@ -192,7 +196,10 @@ class MorningstarDailyReader(_BaseReader):
                     else:
                         pass
             if self.incl_vol is True:
-                bardict.update({"Volume": int(volumes[p] * 1000000)})
+                try:
+                    bardict.update({"Volume": int(volumes[p] * 1000000)})
+                except ValueError:
+                    bardict.update({"Volume": volumes[p]})
             else:
                 pass
 


### PR DESCRIPTION
Fixes #486. Certain Morningstar (index) tickers now use ``np.nan`` to indicate empty volume data. Thanks @ggomarr.

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt
