### PR TITLE
ENH: Add support for AlphaVantage API

### DIFF
--- a/docs/source/readers/alphavantage.rst
+++ b/docs/source/readers/alphavantage.rst
@@ -3,7 +3,7 @@ AlphaVantage
 
 .. py:module:: pandas_datareader.av.forex
 
-.. autoclass:: AlphaVantageForexReader
+.. autoclass:: AVForexReader
    :members:
    :inherited-members:
 

--- a/docs/source/readers/alphavantage.rst
+++ b/docs/source/readers/alphavantage.rst
@@ -1,0 +1,22 @@
+AlphaVantage
+------------
+
+.. py:module:: pandas_datareader.av.forex
+
+.. autoclass:: AlphaVantageForexReader
+   :members:
+   :inherited-members:
+
+
+.. py:module:: pandas_datareader.av.time_series
+
+.. autoclass:: AVTimeSeriesReader
+	:members:
+	:inherited-members:
+
+
+.. py:module:: pandas_datareader.av.sector
+
+.. autoclass:: AVSectorPerformanceReader
+	:members:
+	:inherited-member:

--- a/docs/source/readers/alphavantage.rst
+++ b/docs/source/readers/alphavantage.rst
@@ -19,4 +19,11 @@ AlphaVantage
 
 .. autoclass:: AVSectorPerformanceReader
 	:members:
-	:inherited-member:
+	:inherited-members:
+
+
+.. py:module:: pandas_datareader.av.quotes
+
+.. autoclass:: AVQuotesReader
+	:members:
+	:inherited-members:

--- a/docs/source/readers/index.rst
+++ b/docs/source/readers/index.rst
@@ -4,6 +4,7 @@ Data Readers
 .. toctree::
    :maxdepth: 2
 
+   alphavantage
    fred
    famafrench
    bank-of-canada

--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -181,6 +181,9 @@ symbols. The following endpoints are available:
                        access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
     f.loc["2017-02-09"]
 
+The top-level function ``get_data_av`` is also provided. This function will
+return the ``TIME_SERIES_DAILY`` endpoint for the symbol and date range
+provided.
 
 Forex
 ^^^^^

--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -185,6 +185,25 @@ The top-level function ``get_data_av`` is also provided. This function will
 return the ``TIME_SERIES_DAILY`` endpoint for the symbol and date range
 provided.
 
+Quotes
+^^^^^^
+
+`AlphaVantage <https://www.alphavantage.co/documentation>`__ Batch Stock Quotes
+endpoint allows the retrieval of realtime stock quotes for up to 100 symbols at
+once. These quotes are accessible through the top-level function
+``get_quote_av``.
+
+.. ipython:: python
+
+    import os
+    from datetime import datetime
+    import pandas_datareader.data as web
+
+    web.get_quote_av(["AAPL", "TSLA"])
+
+
+.. note:: Most quotes are only available during market hours.
+
 Forex
 ^^^^^
 

--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -181,7 +181,8 @@ symbols. The following endpoints are available:
                        access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
     f.loc["2017-02-09"]
 
-The top-level function ``get_data_av`` is also provided. This function will
+The top-level function ``get_data_alphavantage`` is also provided. This
+function will
 return the ``TIME_SERIES_DAILY`` endpoint for the symbol and date range
 provided.
 

--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -32,6 +32,7 @@ Currently the following sources are supported:
     - :ref:`Morningstar<remote_data.morningstar>`
     - :ref:`IEX<remote_data.iex>`
     - :ref:`Robinhood<remote_data.robinhood>`
+    - :ref:`AlphaVantage<remote_data.alphavantage>`
     - :ref:`Enigma<remote_data.enigma>`
     - :ref:`Quandl<remote_data.quandl>`
     - :ref:`St.Louis FED (FRED)<remote_data.fred>`
@@ -144,6 +145,84 @@ year relative to today.
     from datetime import datetime
     f = web.DataReader('F', 'robinhood')
     f.head()
+
+
+.. _remote_data.alphavantage
+
+AlphaVantage
+============
+
+`AlphaVantage <https://www.alphavantage.co/documentation>`__ provides realtime
+equities and forex data. Free registration is required to get an API key. 
+
+Historical Time Series Data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Through the 
+`AlphaVantage <https://www.alphavantage.co/documentation>`__ Time Series
+endpoints, it is possible to obtain historical equities data for individual
+symbols. The following endpoints are available:
+
+* ``av-daily`` - Daily Time Series
+* ``av-daily-adjusted`` - Daily Time Series (Adjusted)
+* ``av-weekly`` - Weekly Time Series
+* ``av-weekly-adjusted`` - Weekly Time Series (Adjusted)
+* ``av-monthly`` - Monthly Time Series
+* ``av-monthly-adjusted`` - Monthly Time Series (Adjusted)
+
+.. ipython:: python
+
+    import os
+    from datetime import datetime
+    import pandas_datareader.data as web
+
+    f = web.DataReader("AAPL", "av-daily", start=datetime(2017, 2, 9),
+                       end=datetime(2017, 5, 24),
+                       access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+    f.loc["2017-02-09"]
+
+
+Forex
+^^^^^
+
+`AlphaVantage <https://www.alphavantage.co/documentation>`__ provides realtime
+currency exchange rates (for physical and digital currencies). 
+
+To request the exchange rate of physical or digital currencies, simply format
+as "FROM/TO" as in "USD/JPY".
+
+.. ipython:: python
+
+    import os
+    import pandas_datareader.data as web
+
+    f = web.DataReader("USD/JPY", "av-forex", 
+                       access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+
+Multiple pairs are are allowable:
+
+.. ipython:: python
+
+    import os
+    import pandas_datareader.data as web
+
+    f = web.DataReader(["USD/JPY", "BTC/CNY"], "av-forex",
+                       access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+
+
+Sector Performance
+^^^^^^^^^^^^^^^^^^
+
+`AlphaVantage <https://www.alphavantage.co/documentation>`__ provides sector
+performances through the top-level function ``get_sector_performance_av``.
+
+.. ipython:: python
+
+    import os
+    import pandas_datareader.data as web
+
+    web.get_sector_performance_av().head()
+
 
 .. _remote_data.enigma:
 

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -18,7 +18,7 @@ Enhancements
 
 - A new data connector for data provided by
   `AlphaVantage <https://www.alphavantage.co/documentation>`__ was
-  introduced to obtain forex data.
+  introduced to obtain Foreign Exchange (FX) data.
   (:issue:`389`)
 
 - A new data connector for data provided by
@@ -44,3 +44,4 @@ Bug Fixes
 
 - Added support for passing the API KEY to QuandlReader either directly or by
   setting the environmental variable QUANDL_API_KEY (:issue:`485`).
+- Handle Morningstar index volume data properly (:issue:`486`).

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -32,6 +32,12 @@ Enhancements
   top-level function ``get_sector_performance_av``.
   (:issue:`389`)
 
+  - A new data connector for data provided by
+  `AlphaVantage <https://www.alphavantage.co/documentation>`__ was
+  introduced to obtain real-time Batch Stock Quotes through the
+  top-level function ``get_quote_av``.
+  (:issue:`389`)
+
 .. _whatsnew_070.api_breaking:
 
 Backwards incompatible API changes

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -16,6 +16,22 @@ Highlights include:
 Enhancements
 ~~~~~~~~~~~~
 
+- A new data connector for data provided by
+  `AlphaVantage <https://www.alphavantage.co/documentation>`__ was
+  introduced to obtain forex data.
+  (:issue:`389`)
+
+- A new data connector for data provided by
+  `AlphaVantage <https://www.alphavantage.co/documentation>`__ was
+  introduced to obtain historical time series data.
+  (:issue:`389`)
+
+  - A new data connector for data provided by
+  `AlphaVantage <https://www.alphavantage.co/documentation>`__ was
+  introduced to obtain sector performance data, accessed through the
+  top-level function ``get_sector_performance_av``.
+  (:issue:`389`)
+
 .. _whatsnew_070.api_breaking:
 
 Backwards incompatible API changes
@@ -28,4 +44,3 @@ Bug Fixes
 
 - Added support for passing the API KEY to QuandlReader either directly or by
   setting the environmental variable QUANDL_API_KEY (:issue:`485`).
-- Handle Morningstar index volume data properly (:issue:`486`).

--- a/pandas_datareader/av/__init__.py
+++ b/pandas_datareader/av/__init__.py
@@ -1,0 +1,66 @@
+import os
+
+from pandas_datareader.base import _BaseReader
+from pandas_datareader._utils import RemoteDataError
+
+import pandas as pd
+
+AV_BASE_URL = 'https://www.alphavantage.co/query'
+
+
+class AlphaVantage(_BaseReader):
+    """
+    Base class for all AlphaVantage queries
+    """
+    _format = 'json'
+
+    def __init__(self, symbols=None, start=None, end=None, retry_count=3,
+                 pause=0.001, session=None, api_key=None):
+        super(AlphaVantage, self).__init__(symbols=symbols, start=start,
+                                           end=end, retry_count=retry_count,
+                                           pause=pause, session=session)
+        if api_key is None:
+            api_key = os.getenv('ALPHAVANTAGE_API_KEY')
+        if not api_key or not isinstance(api_key, str):
+            raise ValueError('The AlphaVantage API key must be provided '
+                             'either through the api_key variable or '
+                             'through the environment varaible '
+                             'ALPHAVANTAGE_API_KEY')
+        self.api_key = api_key
+
+    @property
+    def url(self):
+        """ API URL """
+        return AV_BASE_URL
+
+    @property
+    def params(self):
+        return {
+            'symbol': self.symbols,
+            'function': self.function,
+            'apikey': self.api_key
+            }
+
+    @property
+    def function(self):
+        """ AlphaVantage endpoint function"""
+        raise NotImplementedError
+
+    @property
+    def data_key(self):
+        """ Key of data returned from AlphaVantage """
+        raise NotImplementedError
+
+    def _read_lines(self, out):
+        try:
+            df = pd.DataFrame.from_dict(out[self.data_key], orient='index')
+        except KeyError:
+            if "Error Message" in out:
+                raise ValueError("The requested symbol {} could not be "
+                                 "retrived. Check valid ticker"
+                                 ".".format(self.symbols))
+            else:
+                raise RemoteDataError()
+        df.sort_index(ascending=True, inplace=True)
+        df.columns = [id[3:] for id in df.columns]
+        return df

--- a/pandas_datareader/av/__init__.py
+++ b/pandas_datareader/av/__init__.py
@@ -36,10 +36,9 @@ class AlphaVantage(_BaseReader):
     @property
     def params(self):
         return {
-            'symbol': self.symbols,
             'function': self.function,
             'apikey': self.api_key
-            }
+        }
 
     @property
     def function(self):

--- a/pandas_datareader/av/__init__.py
+++ b/pandas_datareader/av/__init__.py
@@ -60,6 +60,7 @@ class AlphaVantage(_BaseReader):
                                  ".".format(self.symbols))
             else:
                 raise RemoteDataError()
-        df.sort_index(ascending=True, inplace=True)
+        df = df[sorted(df.columns)]
+        # df.sort_index(ascending=True, inplace=True)
         df.columns = [id[3:] for id in df.columns]
         return df

--- a/pandas_datareader/av/forex.py
+++ b/pandas_datareader/av/forex.py
@@ -14,7 +14,7 @@ class AVForexReader(AlphaVantage):
 
     Parameters
     ----------
-    pairs : string, array-like object (list, tuple, Series)
+    symbols : string, array-like object (list, tuple, Series)
         Single currency pair (formatted 'FROM/TO') or list of the same.
     retry_count : int, default 3
         Number of times to retry query request.
@@ -27,10 +27,10 @@ class AVForexReader(AlphaVantage):
         AlphaVantage API key . If not provided the environmental variable
         ALPHAVANTAGE_API_KEY is read. The API key is *required*.
     """
-    def __init__(self, pairs=None, retry_count=3, pause=0.5, session=None,
+    def __init__(self, symbols=None, retry_count=3, pause=0.5, session=None,
                  api_key=None):
 
-        super(AVForexReader, self).__init__(symbols=pairs,
+        super(AVForexReader, self).__init__(symbols=symbols,
                                             start=None, end=None,
                                             retry_count=retry_count,
                                             pause=pause,
@@ -39,19 +39,19 @@ class AVForexReader(AlphaVantage):
         self.from_curr = {}
         self.to_curr = {}
         self.optional_params = {}
-        if isinstance(pairs, str):
-            self.pairs = [pairs]
+        if isinstance(symbols, str):
+            self.symbols = [symbols]
         else:
-            self.pairs = pairs
+            self.symbols = symbols
         try:
-            for pair in self.pairs:
+            for pair in self.symbols:
                 self.from_curr[pair] = pair.split('/')[0]
                 self.to_curr[pair] = pair.split('/')[1]
         except Exception as e:
             print(e)
             raise ValueError("Please input a currency pair "
                              "formatted 'FROM/TO' or a list of "
-                             "currency pairs")
+                             "currency symbols")
 
     @property
     def function(self):
@@ -72,7 +72,7 @@ class AVForexReader(AlphaVantage):
 
     def read(self):
         result = []
-        for pair in self.pairs:
+        for pair in self.symbols:
             self.optional_params = {
                 'from_currency': self.from_curr[pair],
                 'to_currency': self.to_curr[pair],
@@ -80,7 +80,7 @@ class AVForexReader(AlphaVantage):
             data = super(AVForexReader, self).read()
             result.append(data)
         df = pd.concat(result, axis=1)
-        df.columns = self.pairs
+        df.columns = self.symbols
         return df
 
     def _read_lines(self, out):

--- a/pandas_datareader/av/forex.py
+++ b/pandas_datareader/av/forex.py
@@ -5,7 +5,7 @@ from pandas_datareader._utils import RemoteDataError
 import pandas as pd
 
 
-class AlphaVantageForexReader(AlphaVantage):
+class AVForexReader(AlphaVantage):
     """
     Returns DataFrame of the AlphaVantage Foreign Exchange (FX) Exchange Rates
     data.
@@ -30,12 +30,12 @@ class AlphaVantageForexReader(AlphaVantage):
     def __init__(self, pairs=None, retry_count=3, pause=0.5, session=None,
                  api_key=None):
 
-        super(AlphaVantageForexReader, self).__init__(symbols=pairs,
-                                                      start=None, end=None,
-                                                      retry_count=retry_count,
-                                                      pause=pause,
-                                                      session=session,
-                                                      api_key=api_key)
+        super(AVForexReader, self).__init__(symbols=pairs,
+                                            start=None, end=None,
+                                            retry_count=retry_count,
+                                            pause=pause,
+                                            session=session,
+                                            api_key=api_key)
         self.from_curr = {}
         self.to_curr = {}
         self.optional_params = {}
@@ -77,7 +77,7 @@ class AlphaVantageForexReader(AlphaVantage):
                 'from_currency': self.from_curr[pair],
                 'to_currency': self.to_curr[pair],
                 }
-            data = super(AlphaVantageForexReader, self).read()
+            data = super(AVForexReader, self).read()
             result.append(data)
         df = pd.concat(result, axis=1)
         df.columns = self.pairs

--- a/pandas_datareader/av/forex.py
+++ b/pandas_datareader/av/forex.py
@@ -1,0 +1,93 @@
+from pandas_datareader.av import AlphaVantage
+
+from pandas_datareader._utils import RemoteDataError
+
+import pandas as pd
+
+
+class AlphaVantageForexReader(AlphaVantage):
+    """
+    Returns DataFrame of the AlphaVantage Foreign Exchange (FX) Exchange Rates
+    data.
+
+    .. versionadded:: 0.7.0
+
+    Parameters
+    ----------
+    pairs : string, array-like object (list, tuple, Series)
+        Single currency pair (formatted 'FROM/TO') or list of the same.
+    retry_count : int, default 3
+        Number of times to retry query request.
+    pause : int, default 0.5
+        Time, in seconds, to pause between consecutive queries of chunks. If
+        single value given for symbol, represents the pause between retries.
+    session : Session, default None
+        requests.sessions.Session instance to be used
+    api_key : str, optional
+        AlphaVantage API key . If not provided the environmental variable
+        ALPHAVANTAGE_API_KEY is read. The API key is *required*.
+    """
+    def __init__(self, pairs=None, retry_count=3, pause=0.5, session=None,
+                 api_key=None):
+
+        super(AlphaVantageForexReader, self).__init__(symbols=pairs,
+                                                      start=None, end=None,
+                                                      retry_count=retry_count,
+                                                      pause=pause,
+                                                      session=session,
+                                                      api_key=api_key)
+        self.from_curr = {}
+        self.to_curr = {}
+        self.optional_params = {}
+        if isinstance(pairs, str):
+            self.pairs = [pairs]
+        else:
+            self.pairs = pairs
+        try:
+            for pair in self.pairs:
+                self.from_curr[pair] = pair.split('/')[0]
+                self.to_curr[pair] = pair.split('/')[1]
+        except Exception as e:
+            print(e)
+            raise ValueError("Please input a currency pair "
+                             "formatted 'FROM/TO' or a list of "
+                             "currency pairs")
+
+    @property
+    def function(self):
+        return 'CURRENCY_EXCHANGE_RATE'
+
+    @property
+    def data_key(self):
+        return 'Realtime Currency Exchange Rate'
+
+    @property
+    def params(self):
+        params = {
+            'apikey': self.api_key,
+            'function': self.function
+            }
+        params.update(self.optional_params)
+        return params
+
+    def read(self):
+        result = []
+        for pair in self.pairs:
+            self.optional_params = {
+                'from_currency': self.from_curr[pair],
+                'to_currency': self.to_curr[pair],
+                }
+            data = super(AlphaVantageForexReader, self).read()
+            result.append(data)
+        df = pd.concat(result, axis=1)
+        df.columns = self.pairs
+        return df
+
+    def _read_lines(self, out):
+        try:
+            df = pd.DataFrame.from_dict(out[self.data_key], orient='index')
+        except KeyError:
+            raise RemoteDataError()
+        df.sort_index(ascending=True, inplace=True)
+        df.index = [id[3:] for id in df.index]
+        return df

--- a/pandas_datareader/av/quotes.py
+++ b/pandas_datareader/av/quotes.py
@@ -1,0 +1,74 @@
+from pandas_datareader.av import AlphaVantage
+
+import pandas as pd
+import numpy as np
+
+
+class AVQuotesReader(AlphaVantage):
+    """
+    Returns DataFrame of AlphaVantage Realtime Stock quotes for a symbol or
+    list of symbols.
+
+    Parameters
+    ----------
+    symbols : string, array-like object (list, tuple, Series), or DataFrame
+        Single stock symbol (ticker), array-like object of symbols or
+        DataFrame with index containing stock symbols.
+    retry_count : int, default 3
+        Number of times to retry query request.
+    pause : int, default 0
+        Time, in seconds, to pause between consecutive queries of chunks. If
+        single value given for symbol, represents the pause between retries.
+    session : Session, default None
+        requests.sessions.Session instance to be used
+    """
+    def __init__(self, symbols=None, retry_count=3, pause=0.5, session=None,
+                 api_key=None):
+        if isinstance(symbols, str):
+            syms = [symbols]
+        elif isinstance(symbols, list):
+            if len(symbols) > 100:
+                raise ValueError("Up to 100 symbols at once are allowed.")
+            else:
+                syms = symbols
+        super(AVQuotesReader, self).__init__(symbols=syms,
+                                             start=None, end=None,
+                                             retry_count=retry_count,
+                                             pause=pause,
+                                             session=session,
+                                             api_key=api_key)
+
+    @property
+    def function(self):
+        return 'BATCH_STOCK_QUOTES'
+
+    @property
+    def data_key(self):
+        return 'Stock Quotes'
+
+    @property
+    def params(self):
+        return {
+            'symbols': ','.join(self.symbols),
+            'function': self.function,
+            'apikey': self.api_key,
+        }
+
+    def _read_lines(self, out):
+        result = []
+        quotes = out[self.data_key]
+        for quote in quotes:
+            df = pd.DataFrame(quote, index=[0])
+            df.columns = [col[3:] for col in df.columns]
+            df.set_index("symbol", inplace=True)
+            df["price"] = df["price"].astype('float64')
+            try:
+                df["volume"] = df["volume"].astype('int64')
+            except ValueError:
+                df["volume"] = [np.nan * len(self.symbols)]
+            result.append(df)
+        if len(result) != len(self.symbols):
+            raise ValueError("Not all symbols downloaded. Check valid "
+                             "ticker(s).")
+        else:
+            return pd.concat(result)

--- a/pandas_datareader/av/sector.py
+++ b/pandas_datareader/av/sector.py
@@ -12,6 +12,8 @@ class AVSectorPerformanceReader(AlphaVantage):
 
     Parameters
     ----------
+    symbols : string, array-like object (list, tuple, Series)
+        Single currency pair (formatted 'FROM/TO') or list of the same.
     retry_count : int, default 3
         Number of times to retry query request.
     pause : int, default 0.5

--- a/pandas_datareader/av/sector.py
+++ b/pandas_datareader/av/sector.py
@@ -24,13 +24,6 @@ class AVSectorPerformanceReader(AlphaVantage):
         ALPHAVANTAGE_API_KEY is read. The API key is *required*.
     """
     @property
-    def params(self):
-        return {
-            'function': self.function,
-            'apikey': self.api_key
-        }
-
-    @property
     def function(self):
         return 'SECTOR'
 

--- a/pandas_datareader/av/sector.py
+++ b/pandas_datareader/av/sector.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from pandas_datareader.av import AlphaVantage
+from pandas_datareader._utils import RemoteDataError
+
+
+class AVSectorPerformanceReader(AlphaVantage):
+    """
+    Returns DataFrame of the AlphaVantage Sector Performances SECTOR data.
+
+    .. versionadded:: 0.7.0
+
+    Parameters
+    ----------
+    retry_count : int, default 3
+        Number of times to retry query request.
+    pause : int, default 0.5
+        Time, in seconds, to pause between consecutive queries of chunks. If
+        single value given for symbol, represents the pause between retries.
+    session : Session, default None
+        requests.sessions.Session instance to be used
+    api_key : str, optional
+        AlphaVantage API key . If not provided the environmental variable
+        ALPHAVANTAGE_API_KEY is read. The API key is *required*.
+    """
+    @property
+    def params(self):
+        return {
+            'function': self.function,
+            'apikey': self.api_key
+        }
+
+    @property
+    def function(self):
+        return 'SECTOR'
+
+    def _read_lines(self, out):
+        if "Information" in out:
+            raise RemoteDataError()
+        else:
+            out.pop("Meta Data")
+        df = pd.DataFrame(out)
+        columns = ["RT", "1D", "5D", "1M", "3M", "YTD", "1Y", "3Y", "5Y",
+                   "10Y"]
+        df.columns = columns
+        return df

--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -1,0 +1,90 @@
+from pandas_datareader.av import AlphaVantage
+
+from datetime import datetime
+
+
+class AVTimeSeriesReader(AlphaVantage):
+    """
+    Returns DataFrame of the AlphaVantage Stock Time Series endpoints
+
+    .. versionadded:: 0.7.0
+
+    Parameters
+    ----------
+    symbols : string
+        Single stock symbol (ticker)
+    start : string, (defaults to '1/1/2010')
+        Starting date, timestamp. Parses many different kind of date
+        representations (e.g., 'JAN-01-2010', '1/1/10', 'Jan, 1, 1980')
+    end : string, (defaults to today)
+        Ending date, timestamp. Same format as starting date.
+    retry_count : int, default 3
+        Number of times to retry query request.
+    pause : int, default 0.5
+        Time, in seconds, to pause between consecutive queries of chunks. If
+        single value given for symbol, represents the pause between retries.
+    session : Session, default None
+        requests.sessions.Session instance to be used
+    api_key : str, optional
+        AlphaVantage API key . If not provided the environmental variable
+        ALPHAVANTAGE_API_KEY is read. The API key is *required*.
+    """
+    _FUNC_TO_DATA_KEY = {
+            "TIME_SERIES_DAILY": "Time Series (Daily)",
+            "TIME_SERIES_DAILY_ADJUSTED": "Time Series (Daily)",
+            "TIME_SERIES_WEEKLY": "Weekly Time Series",
+            "TIME_SERIES_WEEKLY_ADJUSTED": "Weekly Adjusted Time Series",
+            "TIME_SERIES_MONTHLY": "Monthly Time Series",
+            "TIME_SERIES_MONTHLY_ADJUSTED": "Monthly Adjusted Time Series"
+    }
+
+    def __init__(self, symbols=None, function="TIME_SERIES_DAILY",
+                 start=None, end=None, retry_count=3, pause=0.35,
+                 session=None, chunksize=25, api_key=None):
+        super(AVTimeSeriesReader, self).__init__(symbols=symbols, start=start,
+                                                 end=end,
+                                                 retry_count=retry_count,
+                                                 pause=pause, session=session,
+                                                 api_key=api_key)
+
+        self.func = function
+
+    @property
+    def function(self):
+        return self.func
+
+    @property
+    def output_size(self):
+        """ Used to limit the size of the AlphaVantage query when
+        possible.
+        """
+        delta = datetime.now() - self.start
+        return 'full' if delta.days > 80 else 'compact'
+
+    @property
+    def data_key(self):
+        return self._FUNC_TO_DATA_KEY[self.function]
+
+    @property
+    def params(self):
+        return {
+            "symbol": self.symbols,
+            "function": self.function,
+            "apikey": self.api_key,
+            "outputsize": self.output_size
+        }
+
+    def _read_lines(self, out):
+        data = super(AVTimeSeriesReader, self)._read_lines(out)
+        start_str = self.start.strftime('%Y-%m-%d')
+        end_str = self.end.strftime('%Y-%m-%d')
+        data = data.loc[start_str:end_str]
+        if data.empty:
+            raise ValueError("Please input a valid date range")
+        else:
+            for column in data.columns:
+                if column == 'volume':
+                    data[column] = data[column].astype('int64')
+                else:
+                    data[column] = data[column].astype('float64')
+        return data

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -4,7 +4,7 @@ Module contains tools for collecting data from various remote sources
 
 import warnings
 
-from pandas_datareader.av.forex import AlphaVantageForexReader
+from pandas_datareader.av.forex import AVForexReader
 from pandas_datareader.av.sector import AVSectorPerformanceReader
 from pandas_datareader.av.time_series import AVTimeSeriesReader
 from pandas_datareader.bankofcanada import BankOfCanadaReader
@@ -131,7 +131,7 @@ def get_quotes_tiingo(*args, **kwargs):
 
 
 def get_exchange_rate_av(*args, **kwargs):
-    return AlphaVantageForexReader(*args, **kwargs).read()
+    return AVForexReader(*args, **kwargs).read()
 
 
 def get_sector_performance_av(*args, **kwargs):
@@ -324,9 +324,9 @@ def DataReader(name, data_source=None, start=None, end=None,
                               session=session, interval='d').read()
 
     elif data_source == "av-forex":
-        return AlphaVantageForexReader(pairs=name, retry_count=retry_count,
-                                       pause=pause, session=session,
-                                       api_key=access_key).read()
+        return AVForexReader(pairs=name, retry_count=retry_count,
+                             pause=pause, session=session,
+                             api_key=access_key).read()
 
     elif data_source == "av-daily":
         return AVTimeSeriesReader(symbols=name,

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -51,7 +51,7 @@ __all__ = ['get_components_yahoo', 'get_data_enigma', 'get_data_famafrench',
            'DataReader']
 
 
-def get_data_av(*args, **kwargs):
+def get_data_alphavantage(*args, **kwargs):
     return AVTimeSeriesReader(*args, **kwargs).read()
 
 
@@ -329,7 +329,7 @@ def DataReader(name, data_source=None, start=None, end=None,
                               session=session, interval='d').read()
 
     elif data_source == "av-forex":
-        return AVForexReader(pairs=name, retry_count=retry_count,
+        return AVForexReader(symbols=name, retry_count=retry_count,
                              pause=pause, session=session,
                              api_key=access_key).read()
 

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -5,6 +5,7 @@ Module contains tools for collecting data from various remote sources
 import warnings
 
 from pandas_datareader.av.forex import AVForexReader
+from pandas_datareader.av.quotes import AVQuotesReader
 from pandas_datareader.av.sector import AVSectorPerformanceReader
 from pandas_datareader.av.time_series import AVTimeSeriesReader
 from pandas_datareader.bankofcanada import BankOfCanadaReader
@@ -73,6 +74,10 @@ def get_data_yahoo(*args, **kwargs):
 
 def get_data_enigma(*args, **kwargs):
     return EnigmaReader(*args, **kwargs).read()
+
+
+def get_quote_av(*args, **kwargs):
+    return AVQuotesReader(*args, **kwargs).read()
 
 
 def get_data_yahoo_actions(*args, **kwargs):

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -4,6 +4,9 @@ Module contains tools for collecting data from various remote sources
 
 import warnings
 
+from pandas_datareader.av.forex import AlphaVantageForexReader
+from pandas_datareader.av.sector import AVSectorPerformanceReader
+from pandas_datareader.av.time_series import AVTimeSeriesReader
 from pandas_datareader.bankofcanada import BankOfCanadaReader
 from pandas_datareader.edgar import EdgarIndexReader
 from pandas_datareader.enigma import EnigmaReader
@@ -45,6 +48,10 @@ __all__ = ['get_components_yahoo', 'get_data_enigma', 'get_data_famafrench',
            'get_data_morningstar', 'get_data_stooq',
            'get_data_stooq', 'get_data_robinhood', 'get_quotes_robinhood',
            'DataReader']
+
+
+def get_data_av(*args, **kwargs):
+    return AVTimeSeriesReader(*args, **kwargs).read()
 
 
 def get_data_fred(*args, **kwargs):
@@ -121,6 +128,14 @@ def get_data_tiingo(*args, **kwargs):
 
 def get_quotes_tiingo(*args, **kwargs):
     return TiingoQuoteReader(*args, **kwargs).read()
+
+
+def get_exchange_rate_av(*args, **kwargs):
+    return AlphaVantageForexReader(*args, **kwargs).read()
+
+
+def get_sector_performance_av(*args, **kwargs):
+    return AVSectorPerformanceReader(*args, **kwargs).read()
 
 
 def get_markets_iex(*args, **kwargs):
@@ -307,6 +322,53 @@ def DataReader(name, data_source=None, start=None, end=None,
                               adjust_price=False, chunksize=25,
                               retry_count=retry_count, pause=pause,
                               session=session, interval='d').read()
+
+    elif data_source == "av-forex":
+        return AlphaVantageForexReader(pairs=name, retry_count=retry_count,
+                                       pause=pause, session=session,
+                                       api_key=access_key).read()
+
+    elif data_source == "av-daily":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_DAILY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-daily-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_DAILY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
+
+    elif data_source == "av-weekly":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_WEEKLY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-weekly-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_WEEKLY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
+
+    elif data_source == "av-monthly":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_MONTHLY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-monthly-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_MONTHLY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
 
     elif data_source == "google":
         return GoogleDailyReader(symbols=name, start=start, end=end,

--- a/pandas_datareader/tests/av/test_av_forex.py
+++ b/pandas_datareader/tests/av/test_av_forex.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+
+import pandas as pd
+
+from pandas_datareader import data as web
+from pandas.testing import assert_index_equal
+
+TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
+TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
+
+
+class TestAlphaVantageForex(object):
+
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip('lxml')
+
+    def test_bad_pair_format(self):
+        with pytest.raises(ValueError):
+            web.DataReader("BAD FORMAT", "av-forex")
+
+    def test_bad_pairs_format(self):
+        with pytest.raises(ValueError):
+            web.DataReader(["USD/JPY", "BAD FORMAT"], "av-forex")
+
+    def test_one_pair(self):
+        df = web.DataReader("USD/EUR", "av-forex")
+        assert isinstance(df, pd.DataFrame)
+        assert df.loc["To_Currency Name"][0] == "Euro"
+        assert df.loc["Time Zone"][0] == 'UTC'
+
+    def test_multiple_pairs(self):
+        pairs = ["USD/JPY", "EUR/JPY"]
+        df = web.DataReader(pairs, "av-forex")
+        assert isinstance(df, pd.DataFrame)
+        assert_index_equal(pd.Index(pairs), df.columns)

--- a/pandas_datareader/tests/av/test_av_forex.py
+++ b/pandas_datareader/tests/av/test_av_forex.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 
 from pandas_datareader import data as web
-from pandas.testing import assert_index_equal
 
 TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
@@ -16,22 +15,30 @@ class TestAlphaVantageForex(object):
     def setup_class(cls):
         pytest.importorskip('lxml')
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_bad_pair_format(self):
         with pytest.raises(ValueError):
             web.DataReader("BAD FORMAT", "av-forex")
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_bad_pairs_format(self):
         with pytest.raises(ValueError):
             web.DataReader(["USD/JPY", "BAD FORMAT"], "av-forex")
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_one_pair(self):
         df = web.DataReader("USD/EUR", "av-forex")
         assert isinstance(df, pd.DataFrame)
         assert df.loc["To_Currency Name"][0] == "Euro"
         assert df.loc["Time Zone"][0] == 'UTC'
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_multiple_pairs(self):
         pairs = ["USD/JPY", "EUR/JPY"]
         df = web.DataReader(pairs, "av-forex")
         assert isinstance(df, pd.DataFrame)
-        assert_index_equal(pd.Index(pairs), df.columns)
+        assert df.columns.equals(pd.Index(pairs))

--- a/pandas_datareader/tests/av/test_av_quotes.py
+++ b/pandas_datareader/tests/av/test_av_quotes.py
@@ -1,0 +1,43 @@
+import pytest
+
+import pandas_datareader.data as web
+import pandas as pd
+from pandas.testing import assert_index_equal
+
+import numpy as np
+
+
+class TestAVQuotes(object):
+
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip("lxml")
+
+    def test_invalid_symbol(self):
+        with pytest.raises(ValueError):
+            web.get_quote_av("BADSYMBOL")
+
+    def test_bad_multiple_symbol(self):
+        with pytest.raises(ValueError):
+            web.get_quote_av(["AAPL", "BADSYMBOL"])
+
+    def test_single_symbol(self):
+        df = web.get_quote_av("AAPL")
+        assert len(df) == 1
+
+        expected = pd.Index(["price", "volume", "timestamp"])
+        assert_index_equal(df.columns, expected)
+
+    def test_multi_symbol(self):
+        df = web.get_quote_av(["AAPL", "TSLA"])
+        assert len(df) == 2
+
+        expected = pd.Index(["price", "volume", "timestamp"])
+        assert_index_equal(df.columns, expected)
+
+    @pytest.mark.xfail(reason="May return NaN outside of market hours")
+    def test_return_types(self):
+        df = web.get_quote_av("AAPL")
+
+        assert isinstance(df["AAPL"]["price"], np.int64)
+        assert isinstance(df["AAPL"]["volume"], np.float64)

--- a/pandas_datareader/tests/av/test_av_quotes.py
+++ b/pandas_datareader/tests/av/test_av_quotes.py
@@ -1,10 +1,13 @@
+import os
 import pytest
 
 import pandas_datareader.data as web
 import pandas as pd
-from pandas.testing import assert_index_equal
 
 import numpy as np
+
+TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
+TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 
 
 class TestAVQuotes(object):
@@ -13,28 +16,38 @@ class TestAVQuotes(object):
     def setup_class(cls):
         pytest.importorskip("lxml")
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_invalid_symbol(self):
         with pytest.raises(ValueError):
             web.get_quote_av("BADSYMBOL")
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_bad_multiple_symbol(self):
         with pytest.raises(ValueError):
             web.get_quote_av(["AAPL", "BADSYMBOL"])
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_single_symbol(self):
         df = web.get_quote_av("AAPL")
         assert len(df) == 1
 
         expected = pd.Index(["price", "volume", "timestamp"])
-        assert_index_equal(df.columns, expected)
+        assert df.columns.equals(expected)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_multi_symbol(self):
         df = web.get_quote_av(["AAPL", "TSLA"])
         assert len(df) == 2
 
         expected = pd.Index(["price", "volume", "timestamp"])
-        assert_index_equal(df.columns, expected)
+        assert df.columns.equals(expected)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     @pytest.mark.xfail(reason="May return NaN outside of market hours")
     def test_return_types(self):
         df = web.get_quote_av("AAPL")

--- a/pandas_datareader/tests/av/test_av_sector.py
+++ b/pandas_datareader/tests/av/test_av_sector.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pandas_datareader.data import get_sector_performance_av
+
+import pandas as pd
+from pandas.testing import assert_index_equal
+
+
+class TestAVSector(object):
+
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip('lxml')
+
+    def test_sector(self):
+        df = get_sector_performance_av()
+
+        cols = pd.Index(["RT", "1D", "5D", "1M", "3M", "YTD", "1Y", "3Y", "5Y",
+                         "10Y"])
+        assert_index_equal(df.columns, cols)
+        assert "Energy" in df.index
+        assert "Real Estate" in df.index

--- a/pandas_datareader/tests/av/test_av_sector.py
+++ b/pandas_datareader/tests/av/test_av_sector.py
@@ -1,9 +1,12 @@
+import os
 import pytest
 
 from pandas_datareader.data import get_sector_performance_av
 
 import pandas as pd
-from pandas.testing import assert_index_equal
+
+TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
+TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 
 
 class TestAVSector(object):
@@ -12,11 +15,13 @@ class TestAVSector(object):
     def setup_class(cls):
         pytest.importorskip('lxml')
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_sector(self):
         df = get_sector_performance_av()
 
         cols = pd.Index(["RT", "1D", "5D", "1M", "3M", "YTD", "1Y", "3Y", "5Y",
                          "10Y"])
-        assert_index_equal(df.columns, cols)
+        assert df.columns.equals(cols)
         assert "Energy" in df.index
         assert "Real Estate" in df.index

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -1,0 +1,131 @@
+import os
+import pytest
+
+import pandas as pd
+
+from pandas_datareader import data as web
+from pandas.testing import assert_index_equal
+
+from datetime import datetime
+
+TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
+TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
+
+
+class TestAVTimeSeries(object):
+
+    @classmethod
+    def setup_class(cls):
+        pytest.importorskip('lxml')
+        cls.col_index_adj = pd.Index(["open", "high", "low", "close",
+                                      "adjusted close", "volume",
+                                      "dividend amount"])
+        cls.col_index = pd.Index(["open", "high", "low", "close",
+                                 "volume"])
+
+    @property
+    def start(self):
+        return datetime(2015, 2, 9)
+
+    @property
+    def end(self):
+        return datetime(2017, 5, 24)
+
+    def test_av_bad_symbol(self):
+        with pytest.raises(ValueError):
+            web.DataReader("BADTICKER", "av-daily", start=self.start,
+                           end=self.end)
+
+    def test_av_daily(self):
+        df = web.DataReader("AAPL", "av-daily", start=self.start, end=self.end)
+        assert_index_equal(df.columns, self.col_index)
+        assert len(df) == 578
+        assert df["volume"][-1] == 19118319
+
+        expected1 = df.loc["2017-02-09"]
+        assert expected1["close"] == 132.42
+        assert expected1["high"] == 132.445
+
+        expected2 = df.loc["2017-05-24"]
+        assert expected2["close"] == 153.34
+        assert expected2["high"] == 154.17
+
+    def test_av_daily_adjusted(self):
+        df = web.DataReader("AAPL", "av-daily-adjusted", start=self.start,
+                            end=self.end)
+        assert_index_equal(df.columns, pd.Index(["open", "high", "low",
+                                                 "close", "adjusted close",
+                                                 "volume", "dividend amount",
+                                                 "split coefficient"]))
+        assert len(df) == 578
+        assert df["volume"][-1] == 19118319
+
+        expected1 = df.loc["2017-02-09"]
+        assert expected1["close"] == 132.42
+        assert expected1["high"] == 132.445
+        assert expected1["adjusted close"] == 130.3505
+        assert expected1["dividend amount"] == 0.57
+        assert expected1["split coefficient"] == 1.0
+
+        expected2 = df.loc["2017-05-24"]
+        assert expected2["close"] == 153.34
+        assert expected2["high"] == 154.17
+        assert expected2["adjusted close"] == 151.5612
+        assert expected2["dividend amount"] == 0.00
+        assert expected2["split coefficient"] == 1.0
+
+    @staticmethod
+    def _helper_df_weekly_monthly(df, adj=False):
+
+        expected1 = df.loc["2015-02-27"]
+        assert expected1["close"] == 128.46
+        assert expected1["high"] == 133.60
+        if adj:
+            assert expected1["adjusted close"] == 121.5859
+
+        expected2 = df.loc["2017-03-31"]
+        assert expected2["close"] == 143.66
+        assert expected2["high"] == 144.5
+        if adj:
+            assert expected2["adjusted close"] == 141.4148
+            assert expected2["dividend amount"] == 0.00
+
+    def test_av_weekly(self):
+        df = web.DataReader("AAPL", "av-weekly", start=self.start,
+                            end=self.end)
+
+        assert len(df) == 119
+        assert df.iloc[0].name == '2015-02-13'
+        assert df.iloc[-1].name == '2017-05-19'
+        assert_index_equal(df.columns, self.col_index)
+        self._helper_df_weekly_monthly(df, adj=False)
+
+    def test_av_weekly_adjusted(self):
+        df = web.DataReader("AAPL", "av-weekly-adjusted", start=self.start,
+                            end=self.end)
+
+        assert len(df) == 119
+        assert df.iloc[0].name == '2015-02-13'
+        assert df.iloc[-1].name == '2017-05-19'
+        assert_index_equal(df.columns, self.col_index_adj)
+        self._helper_df_weekly_monthly(df, adj=True)
+
+    def test_av_monthly(self):
+        df = web.DataReader("AAPL", "av-monthly", start=self.start,
+                            end=self.end)
+
+        assert len(df) == 27
+        assert df.iloc[0].name == '2015-02-27'
+        assert df.iloc[-1].name == '2017-04-28'
+        assert_index_equal(df.columns, self.col_index)
+        self._helper_df_weekly_monthly(df, adj=False)
+
+    def test_av_monthly_adjusted(self):
+        df = web.DataReader("AAPL", "av-monthly-adjusted", start=self.start,
+                            end=self.end)
+
+        assert_index_equal(df.columns, self.col_index_adj)
+        assert len(df) == 27
+        assert df.iloc[0].name == '2015-02-27'
+        assert df.iloc[-1].name == '2017-04-28'
+        self._helper_df_weekly_monthly(df, adj=True)

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 
 from pandas_datareader import data as web
-from pandas.testing import assert_index_equal
 
 from datetime import datetime
 
@@ -20,8 +19,7 @@ class TestAVTimeSeries(object):
         cls.col_index_adj = pd.Index(["open", "high", "low", "close",
                                       "adjusted close", "volume",
                                       "dividend amount"])
-        cls.col_index = pd.Index(["open", "high", "low", "close",
-                                 "volume"])
+        cls.col_index = pd.Index(["open", "high", "low", "close", "volume"])
 
     @property
     def start(self):
@@ -31,14 +29,18 @@ class TestAVTimeSeries(object):
     def end(self):
         return datetime(2017, 5, 24)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_bad_symbol(self):
         with pytest.raises(ValueError):
             web.DataReader("BADTICKER", "av-daily", start=self.start,
                            end=self.end)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_daily(self):
         df = web.DataReader("AAPL", "av-daily", start=self.start, end=self.end)
-        assert_index_equal(df.columns, self.col_index)
+        assert df.columns.equals(self.col_index)
         assert len(df) == 578
         assert df["volume"][-1] == 19118319
 
@@ -50,13 +52,15 @@ class TestAVTimeSeries(object):
         assert expected2["close"] == 153.34
         assert expected2["high"] == 154.17
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_daily_adjusted(self):
         df = web.DataReader("AAPL", "av-daily-adjusted", start=self.start,
                             end=self.end)
-        assert_index_equal(df.columns, pd.Index(["open", "high", "low",
-                                                 "close", "adjusted close",
-                                                 "volume", "dividend amount",
-                                                 "split coefficient"]))
+        assert df.columns.equals(pd.Index(["open", "high", "low", "close",
+                                           "adjusted close", "volume",
+                                           "dividend amount",
+                                           "split coefficient"]))
         assert len(df) == 578
         assert df["volume"][-1] == 19118319
 
@@ -90,6 +94,8 @@ class TestAVTimeSeries(object):
             assert expected2["adjusted close"] == 141.4148
             assert expected2["dividend amount"] == 0.00
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_weekly(self):
         df = web.DataReader("AAPL", "av-weekly", start=self.start,
                             end=self.end)
@@ -97,9 +103,11 @@ class TestAVTimeSeries(object):
         assert len(df) == 119
         assert df.iloc[0].name == '2015-02-13'
         assert df.iloc[-1].name == '2017-05-19'
-        assert_index_equal(df.columns, self.col_index)
+        assert df.columns.equals(self.col_index)
         self._helper_df_weekly_monthly(df, adj=False)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_weekly_adjusted(self):
         df = web.DataReader("AAPL", "av-weekly-adjusted", start=self.start,
                             end=self.end)
@@ -107,9 +115,11 @@ class TestAVTimeSeries(object):
         assert len(df) == 119
         assert df.iloc[0].name == '2015-02-13'
         assert df.iloc[-1].name == '2017-05-19'
-        assert_index_equal(df.columns, self.col_index_adj)
+        assert df.columns.equals(self.col_index_adj)
         self._helper_df_weekly_monthly(df, adj=True)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_monthly(self):
         df = web.DataReader("AAPL", "av-monthly", start=self.start,
                             end=self.end)
@@ -117,14 +127,16 @@ class TestAVTimeSeries(object):
         assert len(df) == 27
         assert df.iloc[0].name == '2015-02-27'
         assert df.iloc[-1].name == '2017-04-28'
-        assert_index_equal(df.columns, self.col_index)
+        assert df.columns.equals(self.col_index)
         self._helper_df_weekly_monthly(df, adj=False)
 
+    @pytest.mark.skipif(TEST_API_KEY is None,
+                        reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_monthly_adjusted(self):
         df = web.DataReader("AAPL", "av-monthly-adjusted", start=self.start,
                             end=self.end)
 
-        assert_index_equal(df.columns, self.col_index_adj)
+        assert df.columns.equals(self.col_index_adj)
         assert len(df) == 27
         assert df.iloc[0].name == '2015-02-27'
         assert df.iloc[-1].name == '2017-04-28'


### PR DESCRIPTION
# AlphaVantage Readers

Adds support for nearly all of the AlphaVantage API endpoints.

## Additions

- **``AVTimeSeriesReader``** - class to handle requests for data from the Stock Time Series endpoints
  - top-level ``get_data_av``, for TIME_SERIES_DAILY
  - ``av-daily`` for TIME_SERIES_DAILY
  - ``av-daily-adjusted`` for TIME_SERIES_DAILY_ADJUSTED
  - ``av-weekly`` for TIME_SERIES_WEEKLY
  - ``av-weekly-adjusted`` for TIME_SERIES_WEEKLY_ADJUSTED
  - ``av-monthly`` for TIME_SERIES_MONTHLY
  - ``av-monthly-adjusted`` TIME_SERIES_MONTHLY_ADJUSTED
- **``AVQuotesReader``** - class to handle requests for Batch Stock Quotes using top-level ``get_quote_av``
- **``AVForexReader``** - class to handle FX Exchange Rates endpoint (``av-forex`` or top-level ``get_exchange_rate_av``)
- **``AVSectorPerformanceReader``** - class to handle Sector Performances SECTOR endpoint ``av-sector`` or top-level ``get_sector_performance_av``
- ``AlphaVantage``- base class for handling AlphaVantage requests

## Questions

- What format should the sector performances return? As of now, they're strings with a percent sign at the end. Using ``int64`` and ``float64`` for the other new readers.
- Is it okay for ``TimeSeriesReader`` to take the argument ``function`` which allows the selection of the daily/monthly/weekly endpoint? I have an implementation (see [this gist](https://gist.github.com/addisonlynch/91a921fa70c3a8fa647aeffcd562eb04)) which uses separate readers for each (``AVDailyReader``, ``AVDailyAdjustedReader``, etc.). Can switch over to that if it is more in-line with the current style.
- Used AV instead of AlphaVantage in names...readers such as ``AlphaVantageTimeSeriesReader`` seemed a bit long. 

## Needs Help

- **Will need to obtain an API key from AlphaVantage and contact them (support@alphavantage.co) to request an exemption from throttling to allow the tests to run.** Seems they don't like repeated calls to the same endpoints without additional permission. As such, the tests now will pass with an API key that does not have these restrictions, but may fail otherwise.
  - This key will be stored as the environment variable ``ALPHAVANTAGE_API_KEY``

## Near Future

The above takes care of most of the AlphaVantage endpoints. There are two groups remaining:

1. **Digital/Crypto Currencies** - is this something we would want to implement? I don't know if this is a direction you guys would want to head in for PDR. I don't have a lot of knowledge in this sphere, but it seems as if these endpoints could be easily implemented if desired.
2.  **Technical Indicators** - what is the preferred way to implement this?
  AlphaVantage provides 52 technical indicators, each of which seems to take the same default (required) parameters: ``function``, ``symbol``, ``interval``, ``apikey``. However, certain indicators (such as EMA) require additional parameters ``time_period``, ``series_type``, etc. 

In addition, will need to add a reader to handle TIME_SERIES_INTRADAY



- [X] closes #389 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
