### PR TITLE
Allows user to input a custom base url to EnigmaReader

### DIFF
--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -30,3 +30,4 @@ Bug Fixes
   setting the environmental variable QUANDL_API_KEY (:issue:`485`).
 - Added back support for Yahoo! price data
 - Handle Morningstar index volume data properly (:issue:`486`).
+- Added support for optionally passing a custom base_url to the EnigmaReader.

--- a/pandas_datareader/enigma.py
+++ b/pandas_datareader/enigma.py
@@ -13,6 +13,22 @@ class EnigmaReader(_BaseReader):
     Collects current snapshot of Enigma data located at the specified
     data set ID and returns a pandas DataFrame.
 
+    Parameters
+    ----------
+    dataset_id : str
+        Enigma dataset UUID.
+    api_key : str, optional
+        Enigma API key. If not provided, the environmental variable
+        ENIGMA_API_KEY is read.
+    retry_count : int, (defaults to 5)
+        Number of times to retry query request.
+    pause : float, (defaults to 0.75)
+        Time, in seconds, of the pause between retries.
+    session : Session, (defaults to None)
+        requests.sessions.Session instance to be used.
+    base_url : str, optional (defaults to https://public.enigma.com/api)
+        Alternative Enigma endpoint to be used.
+
     Examples
     --------
     Download current snapshot for the following Florida Inspections Dataset:

--- a/pandas_datareader/enigma.py
+++ b/pandas_datareader/enigma.py
@@ -32,7 +32,8 @@ class EnigmaReader(_BaseReader):
                  api_key=None,
                  retry_count=5,
                  pause=.75,
-                 session=None):
+                 session=None,
+                 base_url="https://public.enigma.com/api"):
 
         super(EnigmaReader, self).__init__(symbols=[],
                                            retry_count=retry_count,
@@ -58,7 +59,7 @@ class EnigmaReader(_BaseReader):
             'User-Agent': 'pandas-datareader',
         }
         self.session.headers.update(headers)
-        self._base_url = "https://public.enigma.com/api"
+        self._base_url = base_url
         self._retry_count = retry_count
         self._retry_delay = pause
 


### PR DESCRIPTION
Adds support for optionally passing a custom `base_url` to the `EnigmaReader`. The default behavior will not change, but this will allow the reader to be used with dev/staging instances as well as custom deployments. The feature will also guard against any further domain changes such as in #376.