### PR TITLE
Create a link to Tiingo description in ToC

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -29,6 +29,7 @@ extract data from various Internet sources into a pandas DataFrame.
 Currently the following sources are supported:
 
     - :ref:`Google Finance<remote_data.google>`
+    - :ref:`Tiingo<remote_data.tiingo>`
     - :ref:`Morningstar<remote_data.morningstar>`
     - :ref:`IEX<remote_data.iex>`
     - :ref:`Robinhood<remote_data.robinhood>`


### PR DESCRIPTION
Tiingo is missing a link in Table of Contents

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
