### PR TITLE
FIX: Morningstar Retry Issue

### DIFF
--- a/pandas_datareader/mstar/daily.py
+++ b/pandas_datareader/mstar/daily.py
@@ -62,8 +62,6 @@ class MorningstarDailyReader(_BaseReader):
         self.currency = currency
         self.interval = interval
 
-        self._symbol_data_cache = []
-
     def _url_params(self):
         if self.interval not in ['d', 'wk', 'mo', 'm', 'w']:
             raise ValueError("Invalid interval: valid values are  'd', 'wk' "
@@ -98,9 +96,11 @@ class MorningstarDailyReader(_BaseReader):
         """Not required """
         pass
 
-    def _dl_mult_symbols(self, symbols):
+    def _dl_mult_symbols(self, symbols, symbol_data=None):
         failed = []
-        symbol_data = []
+        if symbol_data is None:
+            symbol_data = []
+        
         for symbol in symbols:
 
             params = self._url_params()
@@ -122,10 +122,9 @@ class MorningstarDailyReader(_BaseReader):
                     jsondata = resp.json()
                     if jsondata is None:
                         failed.append(symbol)
-                        continue
-                    jsdata = self._restruct_json(symbol=symbol,
-                                                 jsondata=jsondata)
-                    symbol_data.extend(jsdata)
+                    else:
+                        jsdata = self._restruct_json(symbol=symbol, jsondata=jsondata)
+                        symbol_data.extend(jsdata)
                 else:
                     raise Exception("Request Error!: %s : %s" % (
                         resp.status_code, resp.reason))
@@ -133,19 +132,19 @@ class MorningstarDailyReader(_BaseReader):
             time.sleep(self.pause)
 
         if len(failed) > 0 and self.retry_count > 0:
-            # TODO: This appears to do nothing since
-            # TODO: successful symbols are not added to
-            self._dl_mult_symbols(symbols=failed)
             self.retry_count -= 1
+            self._dl_mult_symbols(symbols=failed, symbol_data=symbol_data)
         else:
+            # TODO: Redundant?
             self.retry_count = 0
 
-        if not symbol_data:
+        if len(symbol_data) == 0 and self.retry_count == 0:
             raise ValueError('All symbols were invalid')
         elif self.retry_count == 0 and len(failed) > 0:
             warn("The following symbols were excluded do to http "
                  "request errors: \n %s" % failed, SymbolWarning)
-
+            continue
+        
         symbols_df = DataFrame(data=symbol_data)
         dfx = symbols_df.set_index(["Symbol", "Date"])
         return dfx
@@ -156,8 +155,6 @@ class MorningstarDailyReader(_BaseReader):
         return [base + pd.to_timedelta(iv, unit='d') for iv in indexvals]
 
     def _restruct_json(self, symbol, jsondata):
-        if jsondata is None:
-            return
         divdata = jsondata["DividendData"]
 
         pricedata = jsondata["PriceDataList"][0]["Datapoints"]

--- a/pandas_datareader/mstar/daily.py
+++ b/pandas_datareader/mstar/daily.py
@@ -143,8 +143,7 @@ class MorningstarDailyReader(_BaseReader):
         elif self.retry_count == 0 and len(failed) > 0:
             warn("The following symbols were excluded do to http "
                  "request errors: \n %s" % failed, SymbolWarning)
-            continue
-        
+
         symbols_df = DataFrame(data=symbol_data)
         dfx = symbols_df.set_index(["Symbol", "Date"])
         return dfx


### PR DESCRIPTION
symbol_data now carries over in successive recursions of _dl_mult_symbols(). Also eliminated some unused objects and redundancies.

- [x] closes #513 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
