### PR TITLE
COMPAT: Add forward compat for is_list_like

### DIFF
--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -57,3 +57,5 @@ Bug Fixes
 - Fix Yahoo! price data (:issue:`498`)
 - Added back support for Yahoo! price, dividends, and splits data for stocks
 	and currency pairs (:issue:`487`).
+- Add `is_list_like` to compatibility layer to avoid failure on pandas >= 0.23 (:issue:`520`)
+

--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -14,6 +14,7 @@ PANDAS_VERSION = LooseVersion(pd.__version__)
 PANDAS_0190 = (PANDAS_VERSION >= LooseVersion('0.19.0'))
 PANDAS_0200 = (PANDAS_VERSION >= LooseVersion('0.20.0'))
 PANDAS_0210 = (PANDAS_VERSION >= LooseVersion('0.21.0'))
+PANDAS_0230 = (PANDAS_VERSION >= LooseVersion('0.23.0'))
 
 if PANDAS_0190:
     from pandas.api.types import is_number
@@ -38,6 +39,12 @@ if PANDAS_0200:
 else:
     from pandas.util.testing import assertRaisesRegexp as assert_raises_regex
     get_filepath_or_buffer = com.get_filepath_or_buffer
+
+if PANDAS_0230:
+    from pandas.core.dtypes.common import is_list_like
+else:
+    from pandas.core.common import is_list_like
+
 
 if compat.PY3:
     from urllib.error import HTTPError

--- a/pandas_datareader/fred.py
+++ b/pandas_datareader/fred.py
@@ -1,4 +1,5 @@
-from pandas.core.common import is_list_like
+from pandas_datareader.compat import is_list_like
+
 from pandas import concat, read_csv
 
 from pandas_datareader.base import _BaseReader

--- a/pandas_datareader/tests/google/test_google.py
+++ b/pandas_datareader/tests/google/test_google.py
@@ -16,6 +16,9 @@ import warnings
 import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
+pytestmark = pytest.mark.filterwarnings(
+    'ignore::pandas_datareader.exceptions.UnstableAPIWarning')
+
 
 def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     all_nan_cols_dict = {}
@@ -64,8 +67,8 @@ class TestGoogle(object):
         end = datetime(2013, 1, 27)
         for locale in self.locales:
             with tm.set_locale(locale):
-                    panel = web.DataReader("NYSE:F", 'google', start, end)
-                    assert panel.Close[-1] == 13.68
+                panel = web.DataReader("NYSE:F", 'google', start, end)
+                assert panel.Close[-1] == 13.68
 
             with pytest.raises(Exception):
                 web.DataReader('NON EXISTENT TICKER', 'google', start, end)
@@ -153,9 +156,9 @@ class TestGoogle(object):
     def test_dtypes(self):
         # see gh-3995, gh-8980
         data = web.get_data_google(
-                'NYSE:F',
-                start='JAN-01-10',
-                end='JAN-27-13')
+            'NYSE:F',
+            start='JAN-01-10',
+            end='JAN-27-13')
         assert np.issubdtype(data.Open.dtype, np.number)
         assert np.issubdtype(data.Close.dtype, np.number)
         assert np.issubdtype(data.Low.dtype, np.number)
@@ -167,9 +170,9 @@ class TestGoogle(object):
         # see gh-8967
 
         data = web.get_data_google(
-                'NYSE:F',
-                start='JAN-01-10',
-                end='JAN-27-13')
+            'NYSE:F',
+            start='JAN-01-10',
+            end='JAN-27-13')
         assert data.index.name == 'Date'
 
     @skip_on_exception(RemoteDataError)

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -73,7 +73,7 @@ class TestFred(object):
         received = web.DataReader(names, "fred", start, end).head(1)
 
         expected = DataFrame([[217.488, 99.68746, 220.633]], columns=names,
-                             index=[pd.tslib.Timestamp('2010-01-01 00:00:00')])
+                             index=[pd.Timestamp('2010-01-01 00:00:00')])
         expected.index.rename('DATE', inplace=True)
         tm.assert_frame_equal(received, expected, check_less_precise=True)
 


### PR DESCRIPTION
Pandas 0.23 moves is_list_like
Add import to compat

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
