### PR TITLE
CLN/REF: Mark deprecated Google finance API

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -19,16 +19,13 @@ Remote Data Access
 
 .. warning::
 
-  Yahoo! Finance has been immediately deprecated.  Yahoo! substantially
-  altered their API in late 2017 and the csv endpoint was retired.
-
+  Yahoo! Finance and Google Finance hav been immediately deprecated.  Endpoints from both providers have been retired
 .. _remote_data.data_reader:
 
 Functions from :mod:`pandas_datareader.data` and :mod:`pandas_datareader.wb`
 extract data from various Internet sources into a pandas DataFrame.
 Currently the following sources are supported:
 
-    - :ref:`Google Finance<remote_data.google>`
     - :ref:`Tiingo<remote_data.tiingo>`
     - :ref:`Morningstar<remote_data.morningstar>`
     - :ref:`IEX<remote_data.iex>`
@@ -48,25 +45,6 @@ Currently the following sources are supported:
 
 It should be noted, that various sources support different kinds of data, so not all sources implement the same methods and the data elements returned might also differ.
 
-.. _remote_data.google:
-
-Google Finance
-==============
-
-.. warning::
-
-  Google'a API has become less reliable during 2017.  While the google
-  datareader often works as expected, it is not uncommon to experience
-  a range of errors when attempting to read data, especially in bulk.
-
-.. ipython:: python
-
-    import pandas_datareader.data as web
-    import datetime
-    start = datetime.datetime(2010, 1, 1)
-    end = datetime.datetime(2013, 1, 27)
-    f = web.DataReader('F', 'google', start, end)
-    f.ix['2010-01-04']
 
 .. _remote_data.tiingo:
 

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -3,9 +3,14 @@
 v0.7.0 (Xxxxxxx YY, 20ZZ)
 ---------------------------
 
+.. warning::
+
+  Google finance for historical price data has been immediately deprecated.
+
 
 Highlights include:
 
+- Immediate deprecation of Google finance for historical price data, as these API endpoints are no longer supported by the provider. Alternate methods are welcome via pull requests, as PDR would like to restore these features.
 
 .. contents:: What's new in v0.7.0
     :local:
@@ -42,6 +47,8 @@ Enhancements
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Deprecation of Google finance daily reader.  Google retired the remaining financial data end point in June 2018.  It is not possible to reliably retrieve historical price data without this endpoint. The Google daily reader will raise an `ImmediateDeprecationError` when called.
 - When requesting multiple symbols from a DailyReader (ex: google, yahoo, IEX)
   a MultiIndex DataFrame is now returned.  Previously Panel or dict of DataFrames
   were returned. (:issue:`297`).

--- a/pandas_datareader/google/daily.py
+++ b/pandas_datareader/google/daily.py
@@ -1,10 +1,7 @@
 from pandas_datareader.base import _DailyBaseReader
-from pandas_datareader.exceptions import UnstableAPIWarning
+from pandas_datareader.exceptions import ImmediateDeprecationError, \
+    DEP_ERROR_MSG
 
-UNSTABLE_WARNING = """
-The Google Finance API has not been stable since late 2017. Requests seem
-to fail at random. Failure is especially common when bulk downloading.
-"""
 
 
 class GoogleDailyReader(_DailyBaseReader):
@@ -37,8 +34,7 @@ class GoogleDailyReader(_DailyBaseReader):
 
     def __init__(self, symbols=None, start=None, end=None, retry_count=3,
                  pause=0.001, session=None, chunksize=25):
-        import warnings
-        warnings.warn(UNSTABLE_WARNING, UnstableAPIWarning)
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format('Google finance'))
         super(GoogleDailyReader, self).__init__(symbols, start, end,
                                                 retry_count, pause, session,
                                                 chunksize)

--- a/pandas_datareader/google/daily.py
+++ b/pandas_datareader/google/daily.py
@@ -3,7 +3,6 @@ from pandas_datareader.exceptions import ImmediateDeprecationError, \
     DEP_ERROR_MSG
 
 
-
 class GoogleDailyReader(_DailyBaseReader):
     """
     Returns DataFrame of historical stock prices from

--- a/pandas_datareader/tests/google/test_google.py
+++ b/pandas_datareader/tests/google/test_google.py
@@ -18,6 +18,7 @@ from pandas.util.testing import assert_series_equal
 pytestmark = pytest.mark.filterwarnings(
     'ignore::pandas_datareader.exceptions.UnstableAPIWarning')
 
+
 @pytest.mark.xfail(reason="Deprecated")
 def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     all_nan_cols_dict = {}

--- a/pandas_datareader/tests/google/test_google.py
+++ b/pandas_datareader/tests/google/test_google.py
@@ -8,7 +8,6 @@ from pandas import compat
 from datetime import datetime
 from pandas_datareader.data import GoogleDailyReader
 from pandas_datareader._utils import RemoteDataError, SymbolWarning
-from pandas_datareader._testing import skip_on_exception
 
 import requests
 
@@ -19,7 +18,7 @@ from pandas.util.testing import assert_series_equal
 pytestmark = pytest.mark.filterwarnings(
     'ignore::pandas_datareader.exceptions.UnstableAPIWarning')
 
-
+@pytest.mark.xfail(reason="Deprecated")
 def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     all_nan_cols_dict = {}
 
@@ -56,7 +55,7 @@ class TestGoogle(object):
     def teardown_class(cls):
         del cls.locales
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_google(self):
 
         # asserts that google is minimally working and that it throws
@@ -73,6 +72,7 @@ class TestGoogle(object):
             with pytest.raises(Exception):
                 web.DataReader('NON EXISTENT TICKER', 'google', start, end)
 
+    @pytest.mark.xfail(reason="Deprecated")
     def assert_option_result(self, df):
         """
         Validate returned quote data has expected format.
@@ -87,21 +87,21 @@ class TestGoogle(object):
                                         'datetime64[ns]']]
         tm.assert_series_equal(df.dtypes, pd.Series(dtypes, index=exp_columns))
 
-    @pytest.mark.xfail(reason="Google quote api is offline as of Oct 1, 2017")
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_quote_string(self):
         df = web.get_quote_google('GOOG')
         assert df.loc['GOOG', 'last'] > 0.0
         tm.assert_index_equal(df.index, pd.Index(['GOOG']))
         self.assert_option_result(df)
 
-    @pytest.mark.xfail(reason="Google quote api is offline as of Oct 1, 2017")
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_quote_stringlist(self):
         df = web.get_quote_google(['GOOG', 'AMZN', 'GOOG'])
         assert_series_equal(df.iloc[0], df.iloc[2])
         tm.assert_index_equal(df.index, pd.Index(['GOOG', 'AMZN', 'GOOG']))
         self.assert_option_result(df)
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_goog_volume(self):
 
         for locale in self.locales:
@@ -109,7 +109,7 @@ class TestGoogle(object):
                 df = web.get_data_google('GOOG').sort_index()
             assert df.Volume.loc['JAN-02-2015'] == 1446662
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_multi1(self):
         for locale in self.locales:
             sl = ['AAPL', 'AMZN', 'GOOG']
@@ -123,18 +123,19 @@ class TestGoogle(object):
                 with pytest.raises(AttributeError):
                     pan.Close()
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_multi_invalid(self):
         sl = ['AAPL', 'AMZN', 'INVALID']
         data = web.get_data_google(sl, '2012')
         assert 'INVALID' in data.columns.levels[1]
 
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_multi_all_invalid(self):
         sl = ['INVALID', 'INVALID2', 'INVALID3']
         with pytest.raises(RemoteDataError):
             web.get_data_google(sl, '2012')
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_get_multi2(self):
         with warnings.catch_warnings(record=True) as w:
             for locale in self.locales:
@@ -152,7 +153,7 @@ class TestGoogle(object):
                 assert result.shape == (4, 3)
                 assert_n_failed_equals_n_null_columns(w, result)
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_dtypes(self):
         # see gh-3995, gh-8980
         data = web.get_data_google(
@@ -165,7 +166,7 @@ class TestGoogle(object):
         assert np.issubdtype(data.High.dtype, np.number)
         assert np.issubdtype(data.Volume.dtype, np.number)
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_unicode_date(self):
         # see gh-8967
 
@@ -175,7 +176,7 @@ class TestGoogle(object):
             end='JAN-27-13')
         assert data.index.name == 'Date'
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_google_reader_class(self):
 
         r = GoogleDailyReader('GOOG')
@@ -186,6 +187,7 @@ class TestGoogle(object):
         r = GoogleDailyReader('GOOG', session=session)
         assert r.session is session
 
+    @pytest.mark.xfail(reason="Deprecated")
     def test_bad_retry_count(self):
 
         with pytest.raises(ValueError):

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -3,13 +3,11 @@ import pytest
 from pandas import DataFrame
 from pandas_datareader.data import DataReader
 from pandas_datareader.exceptions import UnstableAPIWarning
-from pandas_datareader._utils import RemoteDataError
-from pandas_datareader._testing import skip_on_exception
 
 
 class TestDataReader(object):
 
-    @skip_on_exception(RemoteDataError)
+    @pytest.mark.xfail(reason="Deprecated")
     def test_read_google(self):
         with pytest.warns(UnstableAPIWarning):
             gs = DataReader("GS", "google")


### PR DESCRIPTION
Add immediate deprecation error to Google finance daily reader. Seems as if the previous workaround has been shutdown. Will repair #536 if this is indeed determined to be the case.

- [X] closes #536 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
