### PR TITLE
BUG: Repaired Alphavantage connectors

### DIFF
--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -413,6 +413,53 @@ def DataReader(name, data_source=None, start=None, end=None,
                               retry_count=retry_count, pause=pause,
                               session=session, interval='d').read()
 
+    elif data_source == "av-forex":
+        return AVForexReader(symbols=name, retry_count=retry_count,
+                             pause=pause, session=session,
+                             api_key=access_key).read()
+
+    elif data_source == "av-daily":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_DAILY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-daily-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_DAILY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
+
+    elif data_source == "av-weekly":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_WEEKLY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-weekly-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_WEEKLY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
+
+    elif data_source == "av-monthly":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_MONTHLY", start=start,
+                                  end=end, retry_count=retry_count,
+                                  pause=pause, session=session,
+                                  api_key=access_key).read()
+
+    elif data_source == "av-monthly-adjusted":
+        return AVTimeSeriesReader(symbols=name,
+                                  function="TIME_SERIES_MONTHLY_ADJUSTED",
+                                  start=start, end=end,
+                                  retry_count=retry_count, pause=pause,
+                                  session=session, api_key=access_key).read()
+
     else:
         msg = "data_source=%r is not implemented" % data_source
         raise NotImplementedError(msg)


### PR DESCRIPTION
It looks like the conditionals in data.py for the Alphavantage readers were removed (probably by mistake?) in 350de89. This causes such readers to raise an error when called. This pull restores the correct conditional cases (see below link for diff which causes the problem).

https://github.com/pydata/pandas-datareader/commit/350de8907131ecb74ea885ca40528e099df0f576#diff-c777b33d76c2f7a353162630709f98e5L330

No docs entry needed as the readers have not yet been released.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
