### PR TITLE
Repaired Yahoo actions tests

### DIFF
--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -203,14 +203,14 @@ class TestYahoo(object):
 
         actions = web.get_data_yahoo_actions('BHP.AX', start, end)
 
-        assert sum(actions['action'] == 'DIVIDEND') == 20
+        assert sum(actions['action'] == 'DIVIDEND') == 21
         assert sum(actions['action'] == 'SPLIT') == 1
 
         assert actions.loc['1995-05-11', 'action'][0] == 'SPLIT'
         assert actions.loc['1995-05-11', 'value'][0] == 1 / 1.1
 
         assert actions.loc['1993-05-10', 'action'][0] == 'DIVIDEND'
-        assert actions.loc['1993-05-10', 'value'][0] == 0.3
+        assert actions.loc['1993-05-10', 'value'][0] == 0.21
 
     def test_get_data_yahoo_actions_invalid_symbol(self):
         start = datetime(1990, 1, 1)


### PR DESCRIPTION
For some reason the provider now shows an extra dividend for BHP.AX on 10/27/98 which is incorrect.

```
         action     value
1999-10-29  DIVIDEND  0.250000
1999-05-10  DIVIDEND  0.260000
1998-10-29  DIVIDEND  0.552327
1998-10-27  DIVIDEND  0.250000
1998-05-11  DIVIDEND  0.260000
1997-10-30  DIVIDEND  0.250000
1997-05-12  DIVIDEND  0.260000
```

Also, the 5/10/1993 dividend has now been corrected by the provider from ``0.3`` to ``0.21``.

Here's the correct BHP.AX actions info: http://www.mysharetrading.com/bhp-dividends

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

