### PR TITLE
CLN/REF: Mark Deprecated Morningstar API

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -19,7 +19,7 @@ Remote Data Access
 
 .. warning::
 
-  Yahoo! Finance and Google Finance hav been immediately deprecated.  Endpoints from both providers have been retired
+  Yahoo! Finance, Google Finance, and Morningstar have been immediately deprecated.  Endpoints from these providers have been retired
 
 .. _remote_data.data_reader:
 
@@ -28,7 +28,6 @@ extract data from various Internet sources into a pandas DataFrame.
 Currently the following sources are supported:
 
     - :ref:`Tiingo<remote_data.tiingo>`
-    - :ref:`Morningstar<remote_data.morningstar>`
     - :ref:`IEX<remote_data.iex>`
     - :ref:`Robinhood<remote_data.robinhood>`
     - :ref:`AlphaVantage<remote_data.alphavantage>`
@@ -64,21 +63,6 @@ writing).
     df = pdr.get_data_tiingo('GOOG', api_key=os.getenv('TIINGO_API_KEY'))
     df.head()
 
-.. _remote_data.morningstar:
-
-Morningstar
-===========
-OHLC and Volume data is available from Morningstar using the same API which
-powers their charts.
-
-.. ipython:: python
-
-    import pandas_datareader.data as web
-    from datetime import datetime
-    start = datetime(2015, 2, 9)
-    end = datetime(2017, 5, 24)
-    f = web.DataReader('F', 'morningstar', start, end)
-    f.head()
 
 .. _remote_data.iex:
 
@@ -132,12 +116,12 @@ AlphaVantage
 ============
 
 `AlphaVantage <https://www.alphavantage.co/documentation>`__ provides realtime
-equities and forex data. Free registration is required to get an API key. 
+equities and forex data. Free registration is required to get an API key.
 
 Historical Time Series Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Through the 
+Through the
 `AlphaVantage <https://www.alphavantage.co/documentation>`__ Time Series
 endpoints, it is possible to obtain historical equities data for individual
 symbols. The following endpoints are available:
@@ -188,7 +172,7 @@ Forex
 ^^^^^
 
 `AlphaVantage <https://www.alphavantage.co/documentation>`__ provides realtime
-currency exchange rates (for physical and digital currencies). 
+currency exchange rates (for physical and digital currencies).
 
 To request the exchange rate of physical or digital currencies, simply format
 as "FROM/TO" as in "USD/JPY".
@@ -198,7 +182,7 @@ as "FROM/TO" as in "USD/JPY".
     import os
     import pandas_datareader.data as web
 
-    f = web.DataReader("USD/JPY", "av-forex", 
+    f = web.DataReader("USD/JPY", "av-forex",
                        access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
 
 Multiple pairs are are allowable:
@@ -233,7 +217,7 @@ Enigma
 
 Access datasets from `Enigma <https://public.enigma.com>`__,
 the world's largest repository of structured public data. Note that the Enigma
-URL has changed from `app.enigma.io <https://app.enigma.io>`__ as of release 
+URL has changed from `app.enigma.io <https://app.enigma.io>`__ as of release
 ``0.6.0``, as the old API deprecated.
 
 Datasets are unique identified by the ``uuid4`` at the end of a dataset's web address.
@@ -568,7 +552,7 @@ available. More information on the `field <http://www.nasdaqtrader.com/trader.as
 
 Stooq Index Data
 ================
-Google finance doesn't provide common index data download. The Stooq site has the data for download. 
+Google finance doesn't provide common index data download. The Stooq site has the data for download.
 
 .. ipython:: python
 

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -5,12 +5,12 @@ v0.7.0 (Xxxxxxx YY, 20ZZ)
 
 .. warning::
 
-  Google finance for historical price data has been immediately deprecated.
+  Google finance and Morningstar for historical price data have been immediately deprecated.
 
 
 Highlights include:
 
-- Immediate deprecation of Google finance for historical price data, as these API endpoints are no longer supported by the provider. Alternate methods are welcome via pull requests, as PDR would like to restore these features.
+- Immediate deprecation of Google finance and Morningstar for historical price data, as these API endpoints are no longer supported by their respective providers. Alternate methods are welcome via pull requests, as PDR would like to restore these features.
 
 .. contents:: What's new in v0.7.0
     :local:
@@ -49,6 +49,7 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Deprecation of Google finance daily reader.  Google retired the remaining financial data end point in June 2018.  It is not possible to reliably retrieve historical price data without this endpoint. The Google daily reader will raise an `ImmediateDeprecationError` when called.
+- Deprecation of Morningstar daily reader. Morningstar ended support for the historical price data endpoint in July 2018. It is not possible to retrieve historical price data without this endpoint. The Morningstar daily reader will raise an `ImmediateDeprecationError` when called.
 - When requesting multiple symbols from a DailyReader (ex: google, yahoo, IEX)
   a MultiIndex DataFrame is now returned.  Previously Panel or dict of DataFrames
   were returned. (:issue:`297`).

--- a/pandas_datareader/mstar/daily.py
+++ b/pandas_datareader/mstar/daily.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from pandas_datareader._utils import SymbolWarning
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.exceptions import ImmediateDeprecationError, \
+    DEP_ERROR_MSG
 import pandas as pd
 
 
@@ -52,6 +54,7 @@ class MorningstarDailyReader(_BaseReader):
                  pause=0.1, timeout=30, session=None, freq=None,
                  incl_splits=False, incl_dividends=False, incl_volume=True,
                  currency='usd', interval='d'):
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format("Morningstar"))
         super(MorningstarDailyReader, self).__init__(symbols, start, end,
                                                      retry_count, pause,
                                                      timeout, session, freq)

--- a/pandas_datareader/tests/mstar/test_daily.py
+++ b/pandas_datareader/tests/mstar/test_daily.py
@@ -6,15 +6,13 @@ import pytest
 import requests
 
 import pandas_datareader.data as web
-from pandas_datareader._testing import skip_on_exception
-from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.data import MorningstarDailyReader
 from pandas_datareader._utils import SymbolWarning
 
 
+@pytest.mark.xfail(reason="Deprecated")
 class TestMorningstarDaily(object):
 
-    @skip_on_exception(RemoteDataError)
     def test_invalid_date(self):
         with pytest.raises(ValueError):
             web.DataReader("MSFT", 'morningstar', start="1990-03-A")
@@ -36,20 +34,17 @@ class TestMorningstarDaily(object):
         with pytest.raises(TypeError):
             web.DataReader([12332], data_source='morningstar', retry_count=0)
 
-    @skip_on_exception(RemoteDataError)
     def test_mstar(self):
         start = datetime(2014, 3, 5)
         end = datetime(2018, 1, 18)
         df = web.DataReader('MSFT', 'morningstar', start=start, end=end)
         assert (df['Open'][-1] == 89.8)
 
-    @skip_on_exception(RemoteDataError)
     def test_get_data_single_symbol(self):
         # single symbol
         # just test that we succeed
         web.get_data_morningstar('GOOG')
 
-    @skip_on_exception(RemoteDataError)
     def test_get_data_interval(self):
         # daily interval data
         pan = web.get_data_morningstar(symbols='XOM', start='2013-01-01',
@@ -70,13 +65,11 @@ class TestMorningstarDaily(object):
         with pytest.raises(ValueError):
             web.get_data_morningstar('XOM', interval='NOT VALID')
 
-    @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols(self):
         # just test that we succeed
         sl = ['AAPL', 'AMZN', 'GOOG']
         web.get_data_morningstar(sl, '2012')
 
-    @skip_on_exception(RemoteDataError)
     def test_get_data_multiple_symbols_two_dates(self):
         df = web.get_data_morningstar(symbols=['XOM', 'MSFT'],
                                       start='2013-01-01',
@@ -112,7 +105,6 @@ class TestMorningstarDaily(object):
                                       end='2013-03-04', incl_volume=False)
         assert ("Volume" not in df.keys())
 
-    @skip_on_exception(RemoteDataError)
     def test_mstar_reader_class(self):
         dr = MorningstarDailyReader(symbols="GOOG", interval="d")
         df = dr.read()
@@ -125,7 +117,6 @@ class TestMorningstarDaily(object):
         dr.read()
         assert dr.session is session
 
-    @skip_on_exception(RemoteDataError)
     def test_mstar_DataReader_multi(self):
         start = datetime(2010, 1, 1)
         end = datetime(2015, 5, 9)

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -21,6 +21,7 @@ class TestDataReader(object):
         vix = DataReader("VIXCLS", "fred")
         assert isinstance(vix, DataFrame)
 
+    @pytest.mark.xfail(reason="Deprecated")
     def test_read_mstar(self):
         gs = DataReader("GS", data_source="morningstar")
         assert isinstance(gs, DataFrame)


### PR DESCRIPTION
Per the discussion in #557, Morningstar's support for their historical endpoint seems to have ended. Leaving this here if that is the case. Tests fail due to unrelated FRED issues which are repaired in #559.

- [X] closes #557
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
