### PR TITLE
Update fred.py

### DIFF
--- a/pandas_datareader/fred.py
+++ b/pandas_datareader/fred.py
@@ -1,4 +1,4 @@
-from pandas_datareader.compat import is_list_like
+from pandas.api.types import is_list_like
 
 from pandas import concat, read_csv
 


### PR DESCRIPTION
Because the is_list_like is moved to pandas.api.types, I change the fred.py file which is highlighted in the picture. I replace from pandas.core.common import is_list_like with from pandas.api.types import is_list_like, and it works.

reference：https://stackoverflow.com/questions/50394873/import-pandas-datareader-gives-importerror-cannot-import-name-is-list-like

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
