### PR TITLE
TST: Remove tm.get_data_path use

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -18,6 +18,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.7.0.txt
 .. include:: whatsnew/v0.6.0.txt
 .. include:: whatsnew/v0.5.0.txt
 .. include:: whatsnew/v0.4.0.txt

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -71,7 +71,8 @@ Bug Fixes
 - Updated Google Daily Price API to functional url (:issue:`502`)
 - Fix Yahoo! price data (:issue:`498`)
 - Added back support for Yahoo! price, dividends, and splits data for stocks
-	and currency pairs (:issue:`487`).
+  and currency pairs (:issue:`487`).
 - Add `is_list_like` to compatibility layer to avoid failure on pandas >= 0.23 (:issue:`520`)
 - Fixed Yahoo! time offset (:issue:`487`).
 - Fix Yahoo! quote reader (:issue: `540`)
+- Remove import of deprecated `tm.get_data_path` (:issue: `566`)

--- a/pandas_datareader/conftest.py
+++ b/pandas_datareader/conftest.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def datapath(request):
+    """Get the path to a data file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the file, relative to ``pandas/tests/``
+
+    Returns
+    -------
+    path : path including ``pandas/tests``.
+
+    Raises
+    ------
+    ValueError
+        If the path doesn't exist and the --strict-data-files option is set.
+    """
+    BASE_PATH = os.path.join(os.path.dirname(__file__), 'tests')
+
+    def deco(*args):
+        path = os.path.join(BASE_PATH, *args)
+        if not os.path.exists(path):
+            if request.config.getoption("--strict-data-files"):
+                msg = "Could not find file {} and --strict-data-files is set."
+                raise ValueError(msg.format(path))
+            else:
+                msg = "Could not find {}."
+                pytest.skip(msg.format(path))
+        return path
+    return deco

--- a/pandas_datareader/tests/io/test_jsdmx.py
+++ b/pandas_datareader/tests/io/test_jsdmx.py
@@ -7,79 +7,80 @@ import pandas as pd
 import pandas.util.testing as tm
 import pytest
 
-from pandas_datareader.io import read_jsdmx
 from pandas_datareader.compat import PANDAS_0210
+from pandas_datareader.io import read_jsdmx
 
 
-class TestJSDMX(object):
+@pytest.fixture
+def dirpath(datapath):
+    return datapath("io", "data")
 
-    def setup_method(self, method):
-        self.dirpath = tm.get_data_path()
 
-    @pytest.mark.skipif(not PANDAS_0210, reason='Broken on old pandas')
-    def test_tourism(self):
-        # OECD -> Industry and Services -> Inbound Tourism
-        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx',
-                                         'tourism.json'))
-        assert isinstance(result, pd.DataFrame)
-        jp = result['Japan']
-        visitors = ['China', 'Hong Kong, China',
-                    'Total international arrivals',
-                    'Korea', 'Chinese Taipei', 'United States']
+@pytest.mark.skipif(not PANDAS_0210, reason='Broken on old pandas')
+def test_tourism(dirpath):
+    # OECD -> Industry and Services -> Inbound Tourism
+    result = read_jsdmx(os.path.join(dirpath, 'jsdmx',
+                                     'tourism.json'))
+    assert isinstance(result, pd.DataFrame)
+    jp = result['Japan']
+    visitors = ['China', 'Hong Kong, China',
+                'Total international arrivals',
+                'Korea', 'Chinese Taipei', 'United States']
 
-        exp_col = pd.Index(
-            ['China', 'Hong Kong, China', 'Total international arrivals',
-             'Korea', 'Chinese Taipei', 'United States'],
-            name='Variable')
-        exp_idx = pd.DatetimeIndex(['2008-01-01', '2009-01-01', '2010-01-01',
-                                    '2011-01-01', '2012-01-01', '2013-01-01',
-                                    '2014-01-01', '2015-01-01', '2016-01-01'],
-                                   name='Year')
-        values = [
-            [1000000.0, 550000.0, 8351000.0, 2382000.0, 1390000.0, 768000.0],
-            [1006000.0, 450000.0, 6790000.0, 1587000.0, 1024000.0, 700000.0],
-            [1413000.0, 509000.0, 8611000.0, 2440000.0, 1268000.0, 727000.0],
-            [1043000.0, 365000.0, 6219000.0, 1658000.0, 994000.0, 566000.0],
-            [1430000.0, 482000.0, 8368000.0, 2044000.0, 1467000.0, 717000.0],
-            [1314000.0, 746000.0, 10364000.0, 2456000.0, 2211000.0, 799000.0],
-            [2409000.0, 926000.0, 13413000.0, 2755000.0, 2830000.0, 892000.0],
-            [4993689.0, 1524292.0, 19737409.0, 4002095.0, 3677075.0,
-             1033258.0],
-            [6373564.0, 1839193.0, 24039700.0, 5090302.0, 4167512.0, 1242719.0]
-        ]
-        values = np.array(values, dtype='object')
-        expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
-        tm.assert_frame_equal(jp[visitors], expected)
+    exp_col = pd.Index(
+        ['China', 'Hong Kong, China', 'Total international arrivals',
+         'Korea', 'Chinese Taipei', 'United States'],
+        name='Variable')
+    exp_idx = pd.DatetimeIndex(['2008-01-01', '2009-01-01', '2010-01-01',
+                                '2011-01-01', '2012-01-01', '2013-01-01',
+                                '2014-01-01', '2015-01-01', '2016-01-01'],
+                               name='Year')
+    values = [
+        [1000000.0, 550000.0, 8351000.0, 2382000.0, 1390000.0, 768000.0],
+        [1006000.0, 450000.0, 6790000.0, 1587000.0, 1024000.0, 700000.0],
+        [1413000.0, 509000.0, 8611000.0, 2440000.0, 1268000.0, 727000.0],
+        [1043000.0, 365000.0, 6219000.0, 1658000.0, 994000.0, 566000.0],
+        [1430000.0, 482000.0, 8368000.0, 2044000.0, 1467000.0, 717000.0],
+        [1314000.0, 746000.0, 10364000.0, 2456000.0, 2211000.0, 799000.0],
+        [2409000.0, 926000.0, 13413000.0, 2755000.0, 2830000.0, 892000.0],
+        [4993689.0, 1524292.0, 19737409.0, 4002095.0, 3677075.0,
+         1033258.0],
+        [6373564.0, 1839193.0, 24039700.0, 5090302.0, 4167512.0, 1242719.0]
+    ]
+    values = np.array(values, dtype='object')
+    expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
+    tm.assert_frame_equal(jp[visitors], expected)
 
-    @pytest.mark.skipif(not PANDAS_0210, reason='Broken on old pandas')
-    def test_land_use(self):
-        # OECD -> Environment -> Resources Land Use
-        result = read_jsdmx(os.path.join(self.dirpath, 'jsdmx',
-                                         'land_use.json'))
-        assert isinstance(result, pd.DataFrame)
-        result = result.loc['2010':'2011']
 
-        cols = ['Arable land and permanent crops',
-                'Arable and cropland % land area',
-                'Total area', 'Forest', 'Forest % land area',
-                'Land area', 'Permanent meadows and pastures',
-                'Meadows and pastures % land area', 'Other areas',
-                'Other % land area']
-        exp_col = pd.MultiIndex.from_product([
-            ['Japan', 'United States'],
-            cols], names=['Country', 'Variable'])
-        exp_idx = pd.DatetimeIndex(['2010', '2011'], name='Year')
-        values = [
-            [53790.0, 14.753154141525, 377800.0, np.nan, np.nan, 364600.0,
-             5000.0, 1.3713658804169, np.nan, np.nan,
-             1897990.0, 20.722767650476, 9629090.0, np.nan, np.nan, 9158960.0,
-             2416000.0, 26.378540795025, np.nan,
-             np.nan],
-            [53580.0, 14.691527282698, 377800.0, np.nan, np.nan, 364700.0,
-             5000.0, 1.3709898546751, np.nan, np.nan,
-             1897990.0, 20.722767650476, 9629090.0, np.nan, np.nan, 9158960.0,
-             2416000.0, 26.378540795025, np.nan,
-             np.nan]]
-        values = np.array(values)
-        expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
-        tm.assert_frame_equal(result[exp_col], expected)
+@pytest.mark.skipif(not PANDAS_0210, reason='Broken on old pandas')
+def test_land_use(dirpath):
+    # OECD -> Environment -> Resources Land Use
+    result = read_jsdmx(os.path.join(dirpath, 'jsdmx',
+                                     'land_use.json'))
+    assert isinstance(result, pd.DataFrame)
+    result = result.loc['2010':'2011']
+
+    cols = ['Arable land and permanent crops',
+            'Arable and cropland % land area',
+            'Total area', 'Forest', 'Forest % land area',
+            'Land area', 'Permanent meadows and pastures',
+            'Meadows and pastures % land area', 'Other areas',
+            'Other % land area']
+    exp_col = pd.MultiIndex.from_product([
+        ['Japan', 'United States'],
+        cols], names=['Country', 'Variable'])
+    exp_idx = pd.DatetimeIndex(['2010', '2011'], name='Year')
+    values = [
+        [53790.0, 14.753154141525, 377800.0, np.nan, np.nan, 364600.0,
+         5000.0, 1.3713658804169, np.nan, np.nan,
+         1897990.0, 20.722767650476, 9629090.0, np.nan, np.nan, 9158960.0,
+         2416000.0, 26.378540795025, np.nan,
+         np.nan],
+        [53580.0, 14.691527282698, 377800.0, np.nan, np.nan, 364700.0,
+         5000.0, 1.3709898546751, np.nan, np.nan,
+         1897990.0, 20.722767650476, 9629090.0, np.nan, np.nan, 9158960.0,
+         2416000.0, 26.378540795025, np.nan,
+         np.nan]]
+    values = np.array(values)
+    expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
+    tm.assert_frame_equal(result[exp_col], expected)

--- a/pandas_datareader/tests/io/test_sdmx.py
+++ b/pandas_datareader/tests/io/test_sdmx.py
@@ -5,36 +5,37 @@ import os
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 
 from pandas_datareader.io.sdmx import read_sdmx, _read_sdmx_dsd
 
 
-class TestSDMX(object):
+@pytest.fixture
+def dirpath(datapath):
+    return datapath("io", "data")
 
-    def setup_method(self, method):
-        self.dirpath = tm.get_data_path()
 
-    def test_tourism(self):
-        # Eurostat
-        # Employed doctorate holders in non managerial and non professional
-        # occupations by fields of science (%)
-        dsd = _read_sdmx_dsd(os.path.join(self.dirpath, 'sdmx',
-                                          'DSD_cdh_e_fos.xml'))
-        df = read_sdmx(os.path.join(self.dirpath, 'sdmx',
-                                    'cdh_e_fos.xml'), dsd=dsd)
+def test_tourism(dirpath):
+    # Eurostat
+    # Employed doctorate holders in non managerial and non professional
+    # occupations by fields of science (%)
+    dsd = _read_sdmx_dsd(os.path.join(dirpath, 'sdmx',
+                                      'DSD_cdh_e_fos.xml'))
+    df = read_sdmx(os.path.join(dirpath, 'sdmx',
+                                'cdh_e_fos.xml'), dsd=dsd)
 
-        assert isinstance(df, pd.DataFrame)
-        assert df.shape == (2, 336)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (2, 336)
 
-        df = df['Percentage']['Total']['Natural sciences']
-        df = df[['Norway', 'Poland', 'Portugal', 'Russia']]
+    df = df['Percentage']['Total']['Natural sciences']
+    df = df[['Norway', 'Poland', 'Portugal', 'Russia']]
 
-        exp_col = pd.MultiIndex.from_product([['Norway', 'Poland', 'Portugal',
-                                               'Russia'], ['Annual']],
-                                             names=['GEO', 'FREQ'])
-        exp_idx = pd.DatetimeIndex(['2009', '2006'], name='TIME_PERIOD')
+    exp_col = pd.MultiIndex.from_product([['Norway', 'Poland', 'Portugal',
+                                           'Russia'], ['Annual']],
+                                         names=['GEO', 'FREQ'])
+    exp_idx = pd.DatetimeIndex(['2009', '2006'], name='TIME_PERIOD')
 
-        values = np.array([[20.38, 25.1, 27.77, 38.1],
-                           [25.49, np.nan, 39.05, np.nan]])
-        expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
-        tm.assert_frame_equal(df, expected)
+    values = np.array([[20.38, 25.1, 27.77, 38.1],
+                       [25.49, np.nan, 39.05, np.nan]])
+    expected = pd.DataFrame(values, index=exp_idx, columns=exp_col)
+    tm.assert_frame_equal(df, expected)

--- a/pandas_datareader/tests/yahoo/test_options.py
+++ b/pandas_datareader/tests/yahoo/test_options.py
@@ -50,17 +50,17 @@ def expiry(month, year):
 
 
 @pytest.fixture
-def json1():
-    dirpath = tm.get_data_path()
+def json1(datapath):
+    dirpath = datapath('yahoo', 'data')
     json1 = 'file://' + os.path.join(
         dirpath, 'yahoo_options1.json')
     return json1
 
 
 @pytest.fixture
-def json2():
+def json2(datapath):
     # see gh-22: empty table
-    dirpath = tm.get_data_path()
+    dirpath = datapath('yahoo', 'data')
     json2 = 'file://' + os.path.join(
         dirpath, 'yahoo_options2.json')
     return json2


### PR DESCRIPTION
Remove get_data_path from tests since it was dropped upstream

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
