### PR TITLE
CLN: Remove unused requests dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Up to date remote data access for pandas, works for multiple versions of pandas.
 
 .. image:: https://img.shields.io/pypi/v/pandas-datareader.svg
     :target: https://pypi.python.org/pypi/pandas-datareader/
-    
+
 .. image:: https://travis-ci.org/pydata/pandas-datareader.svg?branch=master
     :target: https://travis-ci.org/pydata/pandas-datareader
 
@@ -72,8 +72,6 @@ Using pandas datareader requires the following packages:
 * pandas>=0.19.2
 * lxml
 * requests>=2.3.0
-* requests-file
-* requests-ftp
 * wrapt
 
 Building the documentation additionally requires:

--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -76,3 +76,4 @@ Bug Fixes
 - Fixed Yahoo! time offset (:issue:`487`).
 - Fix Yahoo! quote reader (:issue: `540`)
 - Remove import of deprecated `tm.get_data_path` (:issue: `566`)
+- Removed unused requests-file and requests-ftp dependencies

--- a/pandas_datareader/_utils.py
+++ b/pandas_datareader/_utils.py
@@ -3,8 +3,6 @@ import datetime as dt
 import requests
 from pandas import to_datetime
 from pandas_datareader.compat import is_number
-from requests_file import FileAdapter
-from requests_ftp import FTPAdapter
 
 
 class SymbolWarning(UserWarning):
@@ -42,7 +40,5 @@ def _sanitize_dates(start, end):
 def _init_session(session, retry_count=3):
     if session is None:
         session = requests.Session()
-        session.mount('file://', FileAdapter())
-        session.mount('ftp://', FTPAdapter())
         # do not set requests max_retries here to support arbitrary pause
     return session

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ lxml
 pandas>=0.19.2
 pytest>=3
 requests>=2.3.0
-requests-file
-requests-ftp
 wrapt
 # Documentation Only
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def readme():
 
 
 INSTALL_REQUIRES = (
-    ['pandas>=0.19.2', 'requests>=2.3.0', 'requests-file', 'requests-ftp', 'wrapt', 'lxml']
+    ['pandas>=0.19.2', 'requests>=2.3.0', 'wrapt', 'lxml']
 )
 
 setup(


### PR DESCRIPTION
``requests-file`` and ``requests-ftp`` are unused in any readers and undocumented. Seems as if they are not currently needed? Can add mounts back to session in future should it become necessary.

cc: @davidastephens 

- [X] closes #xxxx
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt
