### PR TITLE
BUG: Yahoo actions adjustment is incorrect

### DIFF
--- a/docs/source/whatsnew/v0.7.0.txt
+++ b/docs/source/whatsnew/v0.7.0.txt
@@ -67,12 +67,15 @@ Bug Fixes
 - Added support for passing the API KEY to QuandlReader either directly or by
   setting the environmental variable QUANDL_API_KEY (:issue:`485`).
 - Added support for optionally passing a custom base_url to the EnigmaReader  (:issue:`499`).
-- Fix Yahoo! price data (:issue:`498`)
+- Fix Yahoo! price data (:issue:`498`).
 - Added back support for Yahoo! price, dividends, and splits data for stocks
   and currency pairs (:issue:`487`).
-- Add `is_list_like` to compatibility layer to avoid failure on pandas >= 0.23 (:issue:`520`)
+- Add `is_list_like` to compatibility layer to avoid failure on pandas >= 0.23 (:issue:`520`).
 - Fixed Yahoo! time offset (:issue:`487`).
-- Fix Yahoo! quote reader (:issue: `540`)
+- Fix Yahoo! quote reader (:issue: `540`).
 - Remove import of deprecated `tm.get_data_path` (:issue: `566`)
-- Allow full usage of stooq url parameters
-- Removed unused requests-file and requests-ftp dependencies
+- Allow full usage of stooq url parameters.
+- Removed unused requests-file and requests-ftp dependencies.
+- Fix Yahoo! actions issue where the default reporting adjusts dividends. The unadjusted
+  dividends may lack precision due to accumulated numerical error when converting adjusted
+  to the original dividend amount. (:issue: `495`)

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -201,7 +201,8 @@ class TestYahoo(object):
         start = datetime(1990, 1, 1)
         end = datetime(2000, 4, 5)
 
-        actions = web.get_data_yahoo_actions('BHP.AX', start, end)
+        actions = web.get_data_yahoo_actions('BHP.AX', start, end,
+                                             adjust_dividends=True)
 
         assert sum(actions['action'] == 'DIVIDEND') == 21
         assert sum(actions['action'] == 'SPLIT') == 1
@@ -254,7 +255,7 @@ class TestYahoo(object):
                                       3.05, 2.65, 2.65, 2.65]},
                            index=exp_idx)
         exp.index.name = 'Date'
-        tm.assert_frame_equal(result.reindex_like(exp).round(5), exp.round(5))
+        tm.assert_frame_equal(result.reindex_like(exp).round(2), exp.round(2))
 
         result = web.get_data_yahoo_actions('AAPL', start, end,
                                             adjust_dividends=True)

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -181,10 +181,11 @@ class YahooDailyReader(_DailyBaseReader):
                 splits['Splits'] = 1.0 / splits['SplitRatio']
                 prices = prices.join(splits['Splits'], how='outer')
 
-                if 'DIVIDEND' in types and self.adjust_dividends:
+                if 'DIVIDEND' in types and not self.adjust_dividends:
                     # Adjust dividends to deal with splits
                     adj = prices['Splits'].sort_index(ascending=False).fillna(
                         1).cumprod()
+                    adj = 1.0 / adj
                     prices['Dividends'] = prices['Dividends'] * adj
 
         return prices


### PR DESCRIPTION
Fix Yahoo actions dividend adjustment

- [x] closes #495
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt
