### PR TITLE
ENH: Bug fix for downloading index historicals.

### DIFF
--- a/pandas_datareader/stooq.py
+++ b/pandas_datareader/stooq.py
@@ -37,12 +37,13 @@ class StooqDailyReader(_DailyBaseReader):
 
     def _get_params(self, symbol, country='US'):
         symbol_parts = symbol.split(".")
-        if len(symbol_parts) == 1:
-            symbol = ".".join([symbol, country])
-        else:
-            if symbol_parts[1].lower() not in ['de', 'hk', 'hu', 'jp',
-                                               'pl', 'uk', 'us']:
-                symbol = ".".join([symbol, 'US'])
+        if not symbol.startswith('^'):
+            if len(symbol_parts) == 1:
+                symbol = ".".join([symbol, country])
+            else:
+                if symbol_parts[1].lower() not in ['de', 'hk', 'hu', 'jp',
+                                                   'pl', 'uk', 'us']:
+                    symbol = ".".join([symbol, 'US'])
 
         params = {
             's': symbol,


### PR DESCRIPTION
`import pandas_datareader.data as web
f = web.DataReader('^DJI', 'stooq')`

Above code breaks because country code is pre-appended for any symbol. For index data (^dji, ^spx etc), there is no need to pre-append country code. This patch fixes that.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
