### PR TITLE
Fixed two dividend related issues

### DIFF
--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -278,6 +278,24 @@ class TestYahoo(object):
         exp.index.name = 'Date'
         tm.assert_frame_equal(result.reindex_like(exp).round(5), exp.round(5))
 
+
+        # test cases with "1/0" split ratio in actions- no split, just chnage symbol from POT to NTR
+        start = datetime(2017, 12, 30)
+        end = datetime(2018, 12, 30)
+
+        result = web.DataReader('NTR', 'yahoo-actions', start, end)
+
+        exp_idx = pd.DatetimeIndex(['2018-12-28', '2018-09-27',
+                                    '2018-06-28', '2018-03-28',
+                                    '2018-01-02'])
+
+        exp = pd.DataFrame({'action': ['DIVIDEND', 'DIVIDEND', 'DIVIDEND',
+                                       'DIVIDEND', 'SPLIT'],
+                            'value': [0.43, 0.40, 0.40, 0.40, 1.00]},
+                           index=exp_idx)
+        exp.index.name = 'Date'
+        tm.assert_frame_equal(result.reindex_like(exp).round(2), exp.round(2))
+
     @skip_on_exception(RemoteDataError)
     def test_yahoo_DataReader_multi(self):
         start = datetime(2010, 1, 1)

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -174,11 +174,16 @@ class YahooDailyReader(_DailyBaseReader):
 
             if 'SPLIT' in types:
                 splits = actions[actions.Type == 'SPLIT'].copy()
-                splits['SplitRatio'] = splits['Splitratio'].apply(
-                    lambda x: eval(x))
+#                splits['SplitRatio'] = splits['Splitratio'].apply(
+#                    lambda x: eval(x))
+
+                splits['SplitRatio'] = splits.apply(
+                    lambda row: eval(row['Splitratio']) if float(row['Numerator'])>0 else 1, axis = 1 )
+
                 splits = splits.reset_index(drop=True)
                 splits = splits.set_index('Date')
-                splits['Splits'] = 1.0 / splits['SplitRatio']
+#                splits['Splits'] = 1.0 / splits['SplitRatio']
+                splits['Splits'] = splits['SplitRatio']
                 prices = prices.join(splits['Splits'], how='outer')
 
                 if 'DIVIDEND' in types and self.adjust_dividends:

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -174,15 +174,10 @@ class YahooDailyReader(_DailyBaseReader):
 
             if 'SPLIT' in types:
                 splits = actions[actions.Type == 'SPLIT'].copy()
-#                splits['SplitRatio'] = splits['Splitratio'].apply(
-#                    lambda x: eval(x))
-
                 splits['SplitRatio'] = splits.apply(
                     lambda row: eval(row['Splitratio']) if float(row['Numerator'])>0 else 1, axis = 1 )
-
                 splits = splits.reset_index(drop=True)
                 splits = splits.set_index('Date')
-#                splits['Splits'] = 1.0 / splits['SplitRatio']
                 splits['Splits'] = splits['SplitRatio']
                 prices = prices.join(splits['Splits'], how='outer')
 


### PR DESCRIPTION
-Issue 1:  DataReader(symbol, 'yahoo-dividends', start, end) will have divided by zero error for some dividend stocks like "NTR". 

Root cause:  when the stock has event like "1/0 Stock Split", it will fail. 

The fix: do numerator check first before evaluating the split ratio. In the above case, it should be Splitratio=1

-Issue 2:  fixed a bug that failed dividend/split test case of "def test_yahoo_DataReader(self)" in tests/test_yahoo.py.

