### PR TITLE
Limit data use

### DIFF
--- a/pandas_datareader/iex/daily.py
+++ b/pandas_datareader/iex/daily.py
@@ -101,6 +101,16 @@ class IEXDailyReader(_DailyBaseReader):
         elif 1 <= years < 2:
             return "2y"
         elif 0 <= years < 1:
+             estimated_days = ((365 * delta.years) + (30 * delta.months) + (delta.days)) * -1
+            if 0 <= estimated_days < 6:
+                return "5d"
+            elif 6 <= estimated_days < 28:
+                return "1m"
+            elif  28 <= estimated_days < 84:
+                return "3m"
+            elif 84 <= estimated_days < 168:
+                return "6m"
+           
             return "1y"
         else:
             raise ValueError(

--- a/pandas_datareader/iex/daily.py
+++ b/pandas_datareader/iex/daily.py
@@ -106,11 +106,11 @@ class IEXDailyReader(_DailyBaseReader):
                 return "5d"
             elif 6 <= delta_days < 28:
                 return "1m"
-            elif  28 <= delta_days < 84:
+            elif 28 <= delta_days < 84:
                 return "3m"
             elif 84 <= delta_days < 168:
                 return "6m"
-           
+
             return "1y"
         else:
             raise ValueError(

--- a/pandas_datareader/iex/daily.py
+++ b/pandas_datareader/iex/daily.py
@@ -101,7 +101,7 @@ class IEXDailyReader(_DailyBaseReader):
         elif 1 <= years < 2:
             return "2y"
         elif 0 <= years < 1:
-             estimated_days = ((365 * delta.years) + (30 * delta.months) + (delta.days)) * -1
+            estimated_days = ((365 * delta.years) + (30 * delta.months) + (delta.days)) * -1
             if 0 <= estimated_days < 6:
                 return "5d"
             elif 6 <= estimated_days < 28:

--- a/pandas_datareader/tests/test_iex_daily.py
+++ b/pandas_datareader/tests/test_iex_daily.py
@@ -71,19 +71,35 @@ class TestIEXDaily(object):
     def test_range_string_from_date(self):
         syms = ["AAPL"]
 
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=5),
-            end=date.today())._range_string_from_date() == '5d'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=27),
-            end=date.today())._range_string_from_date() == '1m'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=83),
-            end=date.today())._range_string_from_date() == '3m'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=167),
-            end=date.today())._range_string_from_date() == '6m'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=170),
-            end=date.today())._range_string_from_date() == '1y'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=365),
-            end=date.today())._range_string_from_date() == '2y'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=730),
-            end=date.today())._range_string_from_date() == '5y'
-        assert IEXDailyReader(symbols=syms, start=date.today() - timedelta(days=1826),
-            end=date.today())._range_string_from_date() == 'max'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=5),
+                              end=date.today()
+                              )._range_string_from_date() == '5d'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=27),
+                              end=date.today()
+                              )._range_string_from_date() == '1m'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=83),
+                              end=date.today()
+                              )._range_string_from_date() == '3m'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=167),
+                              end=date.today()
+                              )._range_string_from_date() == '6m'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=170),
+                              end=date.today()
+                              )._range_string_from_date() == '1y'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=365),
+                              end=date.today()
+                              )._range_string_from_date() == '2y'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=730),
+                              end=date.today()
+                              )._range_string_from_date() == '5y'
+        assert IEXDailyReader(symbols=syms,
+                              start=date.today() - timedelta(days=1826),
+                              end=date.today()
+                              )._range_string_from_date() == 'max'


### PR DESCRIPTION
Currently the minimum requested data is a full year.  This limits the request to more specific time frames.

The current functionality is undesirable because IEX is no longer unlimited.  After this change, for less than 6 days,  the cost is 50 messages.  Before it was over 3,000.

- [x] tests added / passed