### PR TITLE
BUG/TST: Adjust Alphavantage time series reader to account for descending ordering

### DIFF
--- a/docs/source/whatsnew/v0.8.0.txt
+++ b/docs/source/whatsnew/v0.8.0.txt
@@ -47,3 +47,5 @@ Bug Fixes
 
 - Fix Yahoo! actions issue where dividends are adjusted twice as a result of a
   change to the Yahoo! API. (:issue: `583`)
+- Fix AlphaVantage time series data ordering after provider switch to
+  descending order (maintains ascending order for consistency) (:issue: `662`)

--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -76,6 +76,8 @@ class AVTimeSeriesReader(AlphaVantage):
 
     def _read_lines(self, out):
         data = super(AVTimeSeriesReader, self)._read_lines(out)
+        # reverse since alphavantage returns descending by date
+        data = data[::-1]
         start_str = self.start.strftime('%Y-%m-%d')
         end_str = self.end.strftime('%Y-%m-%d')
         data = data.loc[start_str:end_str]

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -4,6 +4,7 @@ import pytest
 import pandas as pd
 
 from pandas_datareader import data as web
+from pandas_datareader._utils import RemoteDataError
 
 from datetime import datetime
 
@@ -32,7 +33,7 @@ class TestAVTimeSeries(object):
     @pytest.mark.skipif(TEST_API_KEY is None,
                         reason="ALPHAVANTAGE_API_KEY not set")
     def test_av_bad_symbol(self):
-        with pytest.raises(ValueError):
+        with pytest.raises((ValueError, RemoteDataError)):
             web.DataReader("BADTICKER", "av-daily", start=self.start,
                            end=self.end)
 
@@ -42,7 +43,7 @@ class TestAVTimeSeries(object):
         df = web.DataReader("AAPL", "av-daily", start=self.start, end=self.end)
         assert df.columns.equals(self.col_index)
         assert len(df) == 578
-        assert df["volume"][-1] == 19118319
+        assert df["volume"][-1] == 19178000
 
         expected1 = df.loc["2017-02-09"]
         assert expected1["close"] == 132.42
@@ -62,19 +63,17 @@ class TestAVTimeSeries(object):
                                            "dividend amount",
                                            "split coefficient"]))
         assert len(df) == 578
-        assert df["volume"][-1] == 19118319
+        assert df["volume"][-1] == 19178000
 
         expected1 = df.loc["2017-02-09"]
         assert expected1["close"] == 132.42
         assert expected1["high"] == 132.445
-        assert expected1["adjusted close"] == 130.3505
         assert expected1["dividend amount"] == 0.57
         assert expected1["split coefficient"] == 1.0
 
         expected2 = df.loc["2017-05-24"]
         assert expected2["close"] == 153.34
         assert expected2["high"] == 154.17
-        assert expected2["adjusted close"] == 151.5612
         assert expected2["dividend amount"] == 0.00
         assert expected2["split coefficient"] == 1.0
 
@@ -84,15 +83,10 @@ class TestAVTimeSeries(object):
         expected1 = df.loc["2015-02-27"]
         assert expected1["close"] == 128.46
         assert expected1["high"] == 133.60
-        if adj:
-            assert expected1["adjusted close"] == 121.5859
 
         expected2 = df.loc["2017-03-31"]
         assert expected2["close"] == 143.66
         assert expected2["high"] == 144.5
-        if adj:
-            assert expected2["adjusted close"] == 141.4148
-            assert expected2["dividend amount"] == 0.00
 
     @pytest.mark.skipif(TEST_API_KEY is None,
                         reason="ALPHAVANTAGE_API_KEY not set")


### PR DESCRIPTION
Per #662, Alphavantage now returns *descending* time series data. This PR reconciles this change with PDR and reverses the index to maintain ascending order as is standard. Ensures tests are passing.

- [x] closes #662 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt
