### PR TITLE
Making minor changes to eurostat and econdb

### DIFF
--- a/pandas_datareader/eurostat.py
+++ b/pandas_datareader/eurostat.py
@@ -10,7 +10,7 @@ from pandas_datareader.base import _BaseReader
 class EurostatReader(_BaseReader):
     """Get data for the given name from Eurostat."""
 
-    _URL = 'http://www.ec.europa.eu/eurostat/SDMX/diss-web/rest'
+    _URL = 'http://ec.europa.eu/eurostat/SDMX/diss-web/rest'
 
     @property
     def url(self):

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -70,7 +70,7 @@ class TestEurostat(object):
                             end=pd.Timestamp('2013-01-01'))
 
         name = ('All taxes and levies included',
-                'Gigajoules (gross calorific value - GCV)',
+                'Gigajoule (gross calorific value - GCV)',
                 'Euro',
                 'Band D1 : Consumption < 20 GJ',
                 'Natural gas', 'Denmark', 'Semi-annual')


### PR DESCRIPTION
The eurostat tests should now be passing: the url had to be changed slightly and a column renamed.

Moving on to econdb, the test urls appear to be returning blank data: e.g.
https://www.econdb.com/api/series/?ticker=BLS_CU.CUSR0000SA0.M.US&format=json&page_size=500&expand=meta

@econdb would you mind confirming what has changed with the API when you have a moment.

Thanks,
Simon.