### PR TITLE
Correct EcondbReader's API URL format

### DIFF
--- a/pandas_datareader/econdb.py
+++ b/pandas_datareader/econdb.py
@@ -18,7 +18,7 @@ class EcondbReader(_BaseReader):
         if not isinstance(self.symbols, compat.string_types):
             raise ValueError('data name must be string')
 
-        return ('{0}?{1}&format=json&page_size=500&expand=meta'
+        return ('{0}?{1}&format=json&page_size=500&expand=both'
                 .format(self._URL, self.symbols))
 
     def read(self):

--- a/pandas_datareader/econdb.py
+++ b/pandas_datareader/econdb.py
@@ -1,6 +1,5 @@
 import requests
 import pandas as pd
-import pandas.compat as compat
 
 from pandas_datareader.base import _BaseReader
 
@@ -15,7 +14,7 @@ class EcondbReader(_BaseReader):
     @property
     def url(self):
         """API URL"""
-        if not isinstance(self.symbols, compat.string_types):
+        if not isinstance(self.symbols, str):
             raise ValueError('data name must be string')
 
         return ('{0}?{1}&format=json&page_size=500&expand=both'

--- a/pandas_datareader/tests/test_econdb.py
+++ b/pandas_datareader/tests/test_econdb.py
@@ -42,8 +42,8 @@ class TestEcondb(object):
         df = df.astype(np.float)
         jp = np.array([8351000, 6790000, 8611000, 6219000,
                        8368000], dtype=float)
-        us = np.array([175702309, 160507417, 164079732, 167600277,
-                       171320408], dtype=float)
+        us = np.array([175702304, 160507424, 164079728, 167600272,
+                       171320416], dtype=float)
         index = pd.date_range('2008-01-01', '2012-01-01', freq='AS',
                               name='TIME_PERIOD')
 


### PR DESCRIPTION
Sets correct default query parameter before API requests.

Detailed documentation and usage examples to follow in 1 week.
