### PR TITLE
Handle case when response.encoding is None

### DIFF
--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -133,7 +133,8 @@ class _BaseReader(object):
             if response.status_code == requests.codes.ok:
                 return response
 
-            last_response_text = response.text.encode(response.encoding)
+            if response.encoding:
+                last_response_text = response.text.encode(response.encoding)
             time.sleep(pause)
 
             # Increase time between subsequent requests, per subclass.


### PR DESCRIPTION
In some rare situations the response provided by Requests does not provide an encoding for the response content (most probably because there is no content). In these cases the retry code of pandas-datareader fails do the assumption the encoding being present at all times.

This mini PR fixes this issue.