### PR TITLE
Reverse data after slice.

### DIFF
--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -80,11 +80,13 @@ class AVTimeSeriesReader(AlphaVantage):
 
     def _read_lines(self, out):
         data = super(AVTimeSeriesReader, self)._read_lines(out)
-        # reverse since alphavantage returns descending by date
-        data = data[::-1]
         start_str = self.start.strftime('%Y-%m-%d')
         end_str = self.end.strftime('%Y-%m-%d')
         data = data.loc[start_str:end_str]
+
+        # reverse since alphavantage returns descending by date
+        data = data[::-1]
+
         if data.empty:
             raise ValueError("Please input a valid date range")
         else:


### PR DESCRIPTION
Closes #662 by fixing #662.

The problem with #662 was that the reversing of the data happened before the `data.loc[start_str:end_str]`. Unless `start_str` = `end_str`, this would always return empty.

I could have equally made the same fix by changing `data.loc[start_str:end_str]` to `data.loc[end_str:start_str]`.