### PR TITLE
TST: Split tests into stable and unstable readers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 
 env:
   global:
+    - TEST_TYPE="stable and not requires_api_key"
     # Doctr deploy key for pydata/pandas-datareader
     - secure: "iGbOAbBSV5y0TKDh2CifRSk6OpLA9GbEEL/hscHFLSDDUCWcdfvYXda3SWJFWyoQ5QUxSigXWd+ukr4u92d7lmB7m3TWj6BAMNuRpatTgnejLNwLvNeYdvLAxPvx39Cq85frd1Rx1beBLn3h/4wm4Ah+dR5W9NH8+x3OuZMH3Eo="
 
@@ -19,10 +20,18 @@ matrix:
     env: PANDAS=0.23 NUMPY=1.14
   - python: 3.7
     env: PANDAS=0.25 NUMPY=1.17 DOCBUILD=true
+  - python: 3.7
+    env: PANDAS=0.25 NUMPY=1.17
+  - python: 3.7
+    env: TEST_TYPE="not stable" PANDAS=0.25 NUMPY=1.17
   # In allow failures
-  - env: PYTHON=3.7 PANDAS="MASTER"
+  - python: 3.7
+    env: PANDAS="MASTER" NUMPY=1.17
   allow_failures:
-    - env: PYTHON=3.7 PANDAS="MASTER"
+    - python: 3.7
+      env: PANDAS="MASTER" NUMPY=1.17
+    - python: 3.7
+      env: TEST_TYPE="not stable" PANDAS=0.25 NUMPY=1.17
 
 install:
   - source ci/pypi-install.sh;
@@ -31,9 +40,10 @@ install:
   - python setup.py install
 
 script:
-    - pytest -s -r xX --cov-config .coveragerc --cov=pandas_datareader --cov-report xml:/tmp/cov-datareader.xml --junitxml=/tmp/datareader.xml
-    - flake8 --version
-    - flake8 pandas_datareader
+  - if [[ -n "${TEST_TYPE+x}" ]]; then export MARKERS="-m ${TEST_TYPE}"; fi
+  - pytest -s -r xX "${MARKERS}" --cov-config .coveragerc --cov=pandas_datareader --cov-report xml:/tmp/cov-datareader.xml --junitxml=/tmp/datareader.xml
+  - flake8 --version
+  - flake8 pandas_datareader
 
 after_script:
   - |

--- a/ci/pypi-install.sh
+++ b/ci/pypi-install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set +x
 echo "PyPI install"
 
 pip install pip --upgrade

--- a/pandas_datareader/econdb.py
+++ b/pandas_datareader/econdb.py
@@ -1,5 +1,3 @@
-from pandas_datareader.compat import string_types
-
 import requests
 import pandas as pd
 

--- a/pandas_datareader/tests/av/test_av_forex.py
+++ b/pandas_datareader/tests/av/test_av_forex.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 from pandas_datareader import data as web
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 

--- a/pandas_datareader/tests/av/test_av_quotes.py
+++ b/pandas_datareader/tests/av/test_av_quotes.py
@@ -6,6 +6,8 @@ import pandas as pd
 
 import numpy as np
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 

--- a/pandas_datareader/tests/av/test_av_sector.py
+++ b/pandas_datareader/tests/av/test_av_sector.py
@@ -5,6 +5,8 @@ from pandas_datareader.data import get_sector_performance_av
 
 import pandas as pd
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -8,6 +8,8 @@ from pandas_datareader._utils import RemoteDataError
 
 from datetime import datetime
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('ALPHAVANTAGE_API_KEY')
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY
 

--- a/pandas_datareader/tests/io/test_jsdmx.py
+++ b/pandas_datareader/tests/io/test_jsdmx.py
@@ -10,6 +10,8 @@ import pytest
 from pandas_datareader.compat import PANDAS_0210
 from pandas_datareader.io import read_jsdmx
 
+pytestmark = pytest.mark.stable
+
 
 @pytest.fixture
 def dirpath(datapath):

--- a/pandas_datareader/tests/io/test_sdmx.py
+++ b/pandas_datareader/tests/io/test_sdmx.py
@@ -9,6 +9,8 @@ import pytest
 
 from pandas_datareader.io.sdmx import read_sdmx, _read_sdmx_dsd
 
+pytestmark = pytest.mark.stable
+
 
 @pytest.fixture
 def dirpath(datapath):

--- a/pandas_datareader/tests/test_bankofcanada.py
+++ b/pandas_datareader/tests/test_bankofcanada.py
@@ -5,6 +5,8 @@ import pytest
 import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
 
+pytestmark = pytest.mark.stable
+
 
 class TestBankOfCanada(object):
 

--- a/pandas_datareader/tests/test_base.py
+++ b/pandas_datareader/tests/test_base.py
@@ -3,6 +3,8 @@ import requests
 
 import pandas_datareader.base as base
 
+pytestmark = pytest.mark.stable
+
 
 class TestBaseReader(object):
     def test_requests_not_monkey_patched(self):

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -3,6 +3,8 @@ import pytest
 from pandas import DataFrame
 from pandas_datareader.data import DataReader
 
+pytestmark = pytest.mark.stable
+
 
 class TestDataReader(object):
 

--- a/pandas_datareader/tests/test_econdb.py
+++ b/pandas_datareader/tests/test_econdb.py
@@ -2,6 +2,9 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
+import pytest
+
+pytestmark = pytest.mark.stable
 
 
 class TestEcondb(object):

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -5,6 +5,8 @@ from requests.exceptions import HTTPError
 import pandas_datareader as pdr
 import pandas_datareader.data as web
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('ENIGMA_API_KEY')
 
 

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -2,8 +2,12 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas_datareader.data as web
+import pytest
 
 from pandas_datareader.compat import assert_raises_regex
+
+
+pytestmark = pytest.mark.stable
 
 
 class TestEurostat(object):

--- a/pandas_datareader/tests/test_famafrench.py
+++ b/pandas_datareader/tests/test_famafrench.py
@@ -6,6 +6,8 @@ import pandas.util.testing as tm
 import pandas_datareader.data as web
 from pandas_datareader.famafrench import get_available_datasets
 
+pytestmark = pytest.mark.stable
+
 
 class TestFamaFrench(object):
 

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -10,6 +10,8 @@ import pandas_datareader.data as web
 from pandas import DataFrame
 from pandas_datareader._utils import RemoteDataError
 
+pytestmark = pytest.mark.stable
+
 
 class TestFred(object):
 

--- a/pandas_datareader/tests/test_moex.py
+++ b/pandas_datareader/tests/test_moex.py
@@ -3,6 +3,8 @@ import pytest
 from requests.exceptions import HTTPError
 import pandas_datareader.data as web
 
+pytestmark = pytest.mark.stable
+
 
 class TestMoex(object):
     def test_moex_datareader(self):

--- a/pandas_datareader/tests/test_quandl.py
+++ b/pandas_datareader/tests/test_quandl.py
@@ -5,6 +5,8 @@ import pytest
 import pandas_datareader.data as web
 from pandas_datareader.compat import assert_frame_equal
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('QUANDL_API_KEY')
 # Ensure blank TEST_API_KEY not used in pull request
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY

--- a/pandas_datareader/tests/test_stooq.py
+++ b/pandas_datareader/tests/test_stooq.py
@@ -1,5 +1,9 @@
+import pytest
+
 import pandas_datareader.data as web
 from pandas_datareader.data import get_data_stooq
+
+pytestmark = pytest.mark.stable
 
 
 def test_stooq_dji():

--- a/pandas_datareader/tests/test_tiingo.py
+++ b/pandas_datareader/tests/test_tiingo.py
@@ -7,6 +7,8 @@ from pandas_datareader.compat import PY3
 from pandas_datareader.tiingo import TiingoDailyReader, TiingoMetaDataReader, \
     TiingoQuoteReader, TiingoIEXHistoricalReader, get_tiingo_symbols
 
+pytestmark = pytest.mark.requires_api_key
+
 TEST_API_KEY = os.getenv('TIINGO_API_KEY')
 # Ensure blank TEST_API_KEY not used in pull request
 TEST_API_KEY = None if not TEST_API_KEY else TEST_API_KEY

--- a/pandas_datareader/tests/test_tsp.py
+++ b/pandas_datareader/tests/test_tsp.py
@@ -1,6 +1,10 @@
 import datetime as dt
 
+import pytest
+
 import pandas_datareader.tsp as tsp
+
+pytestmark = pytest.mark.stable
 
 
 class TestTSPFunds(object):

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -15,6 +15,8 @@ from pandas_datareader._testing import skip_on_exception
 
 XFAIL_REASON = 'Known connection failures on Yahoo when testing!'
 
+pytestmark = pytest.mark.stable
+
 
 class TestYahoo(object):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lxml
 pandas>=0.19.2
-pytest>=3
+pytest>=4.0.2
 requests>=2.3.0
 wrapt

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,12 @@ force_grid_wrap=0
 combine_as_imports=True
 force_sort_within_sections=True
 line_width=99
+
+[tool:pytest]
+# sync minversion with setup.cfg & install.rst
+minversion = 4.0.2
+testpaths = pandas_datareader
+# tests not marked as stable are unstable
+markers =
+    stable: mark a test as applying to a stable reader
+    requires_api_key: mark a test as requiring an API key


### PR DESCRIPTION
Split test so that travis can become meaningful

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
