### PR TITLE
MAINT: Use isort to add consistency

### DIFF
--- a/pandas_datareader/__init__.py
+++ b/pandas_datareader/__init__.py
@@ -1,13 +1,31 @@
 from ._version import get_versions
-from .data import (DataReader, Options, get_components_yahoo,
-                   get_dailysummary_iex, get_data_enigma, get_data_famafrench,
-                   get_data_fred, get_data_moex, get_data_quandl,
-                   get_data_stooq, get_data_yahoo, get_data_yahoo_actions,
-                   get_iex_book, get_iex_symbols, get_last_iex,
-                   get_markets_iex, get_nasdaq_symbols, get_quote_yahoo,
-                   get_recent_iex, get_records_iex, get_summary_iex,
-                   get_tops_iex, get_data_tiingo, get_iex_data_tiingo,
-                   get_data_alphavantage)
+from .data import (
+    DataReader,
+    Options,
+    get_components_yahoo,
+    get_dailysummary_iex,
+    get_data_alphavantage,
+    get_data_enigma,
+    get_data_famafrench,
+    get_data_fred,
+    get_data_moex,
+    get_data_quandl,
+    get_data_stooq,
+    get_data_tiingo,
+    get_data_yahoo,
+    get_data_yahoo_actions,
+    get_iex_book,
+    get_iex_data_tiingo,
+    get_iex_symbols,
+    get_last_iex,
+    get_markets_iex,
+    get_nasdaq_symbols,
+    get_quote_yahoo,
+    get_recent_iex,
+    get_records_iex,
+    get_summary_iex,
+    get_tops_iex,
+)
 
 __version__ = get_versions()['version']
 del get_versions

--- a/pandas_datareader/_utils.py
+++ b/pandas_datareader/_utils.py
@@ -1,7 +1,8 @@
 import datetime as dt
 
-import requests
 from pandas import to_datetime
+import requests
+
 from pandas_datareader.compat import is_number
 
 

--- a/pandas_datareader/av/__init__.py
+++ b/pandas_datareader/av/__init__.py
@@ -1,9 +1,9 @@
 import os
 
-from pandas_datareader.base import _BaseReader
-from pandas_datareader._utils import RemoteDataError
-
 import pandas as pd
+
+from pandas_datareader._utils import RemoteDataError
+from pandas_datareader.base import _BaseReader
 
 AV_BASE_URL = 'https://www.alphavantage.co/query'
 

--- a/pandas_datareader/av/forex.py
+++ b/pandas_datareader/av/forex.py
@@ -1,8 +1,7 @@
-from pandas_datareader.av import AlphaVantage
+import pandas as pd
 
 from pandas_datareader._utils import RemoteDataError
-
-import pandas as pd
+from pandas_datareader.av import AlphaVantage
 
 
 class AVForexReader(AlphaVantage):

--- a/pandas_datareader/av/quotes.py
+++ b/pandas_datareader/av/quotes.py
@@ -1,7 +1,7 @@
-from pandas_datareader.av import AlphaVantage
-
-import pandas as pd
 import numpy as np
+import pandas as pd
+
+from pandas_datareader.av import AlphaVantage
 
 
 class AVQuotesReader(AlphaVantage):

--- a/pandas_datareader/av/sector.py
+++ b/pandas_datareader/av/sector.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from pandas_datareader.av import AlphaVantage
 from pandas_datareader._utils import RemoteDataError
+from pandas_datareader.av import AlphaVantage
 
 
 class AVSectorPerformanceReader(AlphaVantage):

--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -1,6 +1,6 @@
-from pandas_datareader.av import AlphaVantage
-
 from datetime import datetime
+
+from pandas_datareader.av import AlphaVantage
 
 
 class AVTimeSeriesReader(AlphaVantage):

--- a/pandas_datareader/bankofcanada.py
+++ b/pandas_datareader/bankofcanada.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
 
-from pandas_datareader.compat import string_types
-
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.compat import string_types
 
 
 class BankOfCanadaReader(_BaseReader):

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -1,17 +1,23 @@
 import time
 import warnings
-import numpy as np
 
+import numpy as np
+from pandas import DataFrame, concat, read_csv
+from pandas.io.common import urlencode
 import requests
 
-from pandas import DataFrame
-from pandas import read_csv, concat
-from pandas.io.common import urlencode
-from pandas_datareader.compat import bytes_to_str, string_types, binary_type, \
-    StringIO
-
-from pandas_datareader._utils import (RemoteDataError, SymbolWarning,
-                                      _sanitize_dates, _init_session)
+from pandas_datareader._utils import (
+    RemoteDataError,
+    SymbolWarning,
+    _init_session,
+    _sanitize_dates,
+)
+from pandas_datareader.compat import (
+    StringIO,
+    binary_type,
+    bytes_to_str,
+    string_types,
+)
 
 
 class _BaseReader(object):

--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -1,8 +1,9 @@
 # flake8: noqa
+from distutils.version import LooseVersion
+import sys
+
 import pandas as pd
 import pandas.io.common as com
-import sys
-from distutils.version import LooseVersion
 
 PY3 = sys.version_info >= (3, 0)
 

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -12,26 +12,36 @@ from pandas_datareader.bankofcanada import BankOfCanadaReader
 from pandas_datareader.econdb import EcondbReader
 from pandas_datareader.enigma import EnigmaReader
 from pandas_datareader.eurostat import EurostatReader
-from pandas_datareader.exceptions import DEP_ERROR_MSG, \
-    ImmediateDeprecationError
+from pandas_datareader.exceptions import (
+    DEP_ERROR_MSG,
+    ImmediateDeprecationError,
+)
 from pandas_datareader.famafrench import FamaFrenchReader
 from pandas_datareader.fred import FredReader
 from pandas_datareader.iex.daily import IEXDailyReader
 from pandas_datareader.iex.deep import Deep as IEXDeep
-from pandas_datareader.iex.tops import LastReader as IEXLasts, \
-    TopsReader as IEXTops
+from pandas_datareader.iex.tops import (
+    LastReader as IEXLasts,
+    TopsReader as IEXTops,
+)
 from pandas_datareader.moex import MoexReader
 from pandas_datareader.nasdaq_trader import get_nasdaq_symbols
 from pandas_datareader.oecd import OECDReader
 from pandas_datareader.quandl import QuandlReader
-from pandas_datareader.robinhood import RobinhoodHistoricalReader, \
-    RobinhoodQuoteReader
+from pandas_datareader.robinhood import (
+    RobinhoodHistoricalReader,
+    RobinhoodQuoteReader,
+)
 from pandas_datareader.stooq import StooqDailyReader
-from pandas_datareader.tiingo import (TiingoDailyReader, TiingoQuoteReader,
-                                      TiingoIEXHistoricalReader)
-from pandas_datareader.yahoo.actions import (YahooActionReader, YahooDivReader)
-from pandas_datareader.yahoo.components import _get_data as \
-    get_components_yahoo
+from pandas_datareader.tiingo import (
+    TiingoDailyReader,
+    TiingoIEXHistoricalReader,
+    TiingoQuoteReader,
+)
+from pandas_datareader.yahoo.actions import YahooActionReader, YahooDivReader
+from pandas_datareader.yahoo.components import (
+    _get_data as get_components_yahoo,
+)
 from pandas_datareader.yahoo.daily import YahooDailyReader
 from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.yahoo.quotes import YahooQuotesReader

--- a/pandas_datareader/econdb.py
+++ b/pandas_datareader/econdb.py
@@ -1,5 +1,5 @@
-import requests
 import pandas as pd
+import requests
 
 from pandas_datareader.base import _BaseReader
 

--- a/pandas_datareader/eurostat.py
+++ b/pandas_datareader/eurostat.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 
 import pandas as pd
 
-from pandas_datareader.io.sdmx import read_sdmx, _read_sdmx_dsd
-from pandas_datareader.compat import string_types
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.compat import string_types
+from pandas_datareader.io.sdmx import _read_sdmx_dsd, read_sdmx
 
 
 class EurostatReader(_BaseReader):

--- a/pandas_datareader/famafrench.py
+++ b/pandas_datareader/famafrench.py
@@ -1,13 +1,12 @@
 import datetime as dt
 import re
 import tempfile
-
 from zipfile import ZipFile
 
 from pandas import read_csv, to_datetime
-from pandas_datareader.compat import lmap, StringIO
 
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.compat import StringIO, lmap
 
 _URL = 'http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/'
 _URL_PREFIX = 'ftp/'

--- a/pandas_datareader/fred.py
+++ b/pandas_datareader/fred.py
@@ -1,8 +1,7 @@
-from pandas_datareader.compat import is_list_like
-
 from pandas import concat, read_csv
 
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.compat import is_list_like
 
 
 class FredReader(_BaseReader):

--- a/pandas_datareader/iex/__init__.py
+++ b/pandas_datareader/iex/__init__.py
@@ -2,8 +2,8 @@ import json
 
 import pandas as pd
 from pandas.io.common import urlencode
-from pandas_datareader.base import _BaseReader
 
+from pandas_datareader.base import _BaseReader
 
 # Data provided for free by IEX
 # Data is furnished in compliance with the guidelines promulgated in the IEX

--- a/pandas_datareader/iex/daily.py
+++ b/pandas_datareader/iex/daily.py
@@ -2,9 +2,9 @@ import datetime
 import json
 import os
 
+from dateutil.relativedelta import relativedelta
 import pandas as pd
 
-from dateutil.relativedelta import relativedelta
 from pandas_datareader.base import _DailyBaseReader
 
 # Data provided for free by IEX

--- a/pandas_datareader/iex/deep.py
+++ b/pandas_datareader/iex/deep.py
@@ -1,5 +1,6 @@
-from pandas_datareader.iex import IEX
 from datetime import datetime
+
+from pandas_datareader.iex import IEX
 
 # Data provided for free by IEX
 # Data is furnished in compliance with the guidelines promulgated in the IEX

--- a/pandas_datareader/iex/stats.py
+++ b/pandas_datareader/iex/stats.py
@@ -5,7 +5,6 @@ import pandas as pd
 from pandas_datareader.exceptions import UnstableAPIWarning
 from pandas_datareader.iex import IEX
 
-
 # Data provided for free by IEX
 # Data is furnished in compliance with the guidelines promulgated in the IEX
 # API terms of service and manual

--- a/pandas_datareader/io/jsdmx.py
+++ b/pandas_datareader/io/jsdmx.py
@@ -1,8 +1,8 @@
 # pylint: disable-msg=E1101,W0613,W0603
 
 from __future__ import unicode_literals
-from collections import OrderedDict
 
+from collections import OrderedDict
 import itertools
 import sys
 

--- a/pandas_datareader/io/sdmx.py
+++ b/pandas_datareader/io/sdmx.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals
 
 import collections
+from io import BytesIO
 import time
 import zipfile
-from io import BytesIO
 
 import pandas as pd
 
-from pandas_datareader.io.util import _read_content
 from pandas_datareader.compat import HTTPError, str_to_bytes
-
+from pandas_datareader.io.util import _read_content
 
 _STRUCTURE = '{http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure}'
 _MESSAGE = '{http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message}'

--- a/pandas_datareader/moex.py
+++ b/pandas_datareader/moex.py
@@ -5,9 +5,12 @@ import datetime as dt
 import pandas as pd
 
 from pandas_datareader.base import _DailyBaseReader
-from pandas_datareader.compat import (binary_type, concat, is_list_like,
-                                      StringIO)
-
+from pandas_datareader.compat import (
+    StringIO,
+    binary_type,
+    concat,
+    is_list_like,
+)
 
 
 class MoexReader(_DailyBaseReader):

--- a/pandas_datareader/nasdaq_trader.py
+++ b/pandas_datareader/nasdaq_trader.py
@@ -1,11 +1,11 @@
 from ftplib import FTP, all_errors
-
-from pandas import read_csv
-from pandas_datareader._utils import RemoteDataError
-from pandas_datareader.compat import StringIO
-
 import time
 import warnings
+
+from pandas import read_csv
+
+from pandas_datareader._utils import RemoteDataError
+from pandas_datareader.compat import StringIO
 
 _NASDAQ_TICKER_LOC = '/SymbolDirectory/nasdaqtraded.txt'
 _NASDAQ_FTP_SERVER = 'ftp.nasdaqtrader.com'

--- a/pandas_datareader/oecd.py
+++ b/pandas_datareader/oecd.py
@@ -1,8 +1,8 @@
 import pandas as pd
 
-from pandas_datareader.io import read_jsdmx
 from pandas_datareader.base import _BaseReader
 from pandas_datareader.compat import string_types
+from pandas_datareader.io import read_jsdmx
 
 
 class OECDReader(_BaseReader):

--- a/pandas_datareader/robinhood.py
+++ b/pandas_datareader/robinhood.py
@@ -1,8 +1,10 @@
 import pandas as pd
 
 from pandas_datareader.base import _BaseReader
-from pandas_datareader.exceptions import (ImmediateDeprecationError,
-                                          DEP_ERROR_MSG)
+from pandas_datareader.exceptions import (
+    DEP_ERROR_MSG,
+    ImmediateDeprecationError,
+)
 
 
 class RobinhoodQuoteReader(_BaseReader):

--- a/pandas_datareader/tests/av/test_av_forex.py
+++ b/pandas_datareader/tests/av/test_av_forex.py
@@ -1,7 +1,7 @@
 import os
-import pytest
 
 import pandas as pd
+import pytest
 
 from pandas_datareader import data as web
 

--- a/pandas_datareader/tests/av/test_av_quotes.py
+++ b/pandas_datareader/tests/av/test_av_quotes.py
@@ -1,10 +1,10 @@
 import os
+
+import numpy as np
+import pandas as pd
 import pytest
 
 import pandas_datareader.data as web
-import pandas as pd
-
-import numpy as np
 
 pytestmark = pytest.mark.requires_api_key
 

--- a/pandas_datareader/tests/av/test_av_sector.py
+++ b/pandas_datareader/tests/av/test_av_sector.py
@@ -1,9 +1,9 @@
 import os
+
+import pandas as pd
 import pytest
 
 from pandas_datareader.data import get_sector_performance_av
-
-import pandas as pd
 
 pytestmark = pytest.mark.requires_api_key
 

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -1,12 +1,11 @@
+from datetime import datetime
 import os
-import pytest
 
 import pandas as pd
+import pytest
 
 from pandas_datareader import data as web
 from pandas_datareader._utils import RemoteDataError
-
-from datetime import datetime
 
 pytestmark = pytest.mark.requires_api_key
 

--- a/pandas_datareader/tests/io/test_sdmx.py
+++ b/pandas_datareader/tests/io/test_sdmx.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pandas.util.testing as tm
 import pytest
 
-from pandas_datareader.io.sdmx import read_sdmx, _read_sdmx_dsd
+from pandas_datareader.io.sdmx import _read_sdmx_dsd, read_sdmx
 
 pytestmark = pytest.mark.stable
 

--- a/pandas_datareader/tests/test_bankofcanada.py
+++ b/pandas_datareader/tests/test_bankofcanada.py
@@ -2,8 +2,8 @@ from datetime import date, timedelta
 
 import pytest
 
-import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
+import pandas_datareader.data as web
 
 pytestmark = pytest.mark.stable
 

--- a/pandas_datareader/tests/test_data.py
+++ b/pandas_datareader/tests/test_data.py
@@ -1,6 +1,6 @@
+from pandas import DataFrame
 import pytest
 
-from pandas import DataFrame
 from pandas_datareader.data import DataReader
 
 pytestmark = pytest.mark.stable

--- a/pandas_datareader/tests/test_econdb.py
+++ b/pandas_datareader/tests/test_econdb.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
-import pandas_datareader.data as web
 import pytest
+
+import pandas_datareader.data as web
 
 pytestmark = pytest.mark.stable
 

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -1,7 +1,8 @@
 import os
-import pytest
 
+import pytest
 from requests.exceptions import HTTPError
+
 import pandas_datareader as pdr
 import pandas_datareader.data as web
 

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -1,11 +1,10 @@
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
-import pandas_datareader.data as web
 import pytest
 
 from pandas_datareader.compat import assert_raises_regex
-
+import pandas_datareader.data as web
 
 pytestmark = pytest.mark.stable
 

--- a/pandas_datareader/tests/test_famafrench.py
+++ b/pandas_datareader/tests/test_famafrench.py
@@ -1,7 +1,6 @@
-import pytest
-
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 
 import pandas_datareader.data as web
 from pandas_datareader.famafrench import get_available_datasets

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -1,14 +1,13 @@
 from datetime import datetime
 
-import pytest
-
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
-import pandas_datareader.data as web
-
 from pandas import DataFrame
+import pandas.util.testing as tm
+import pytest
+
 from pandas_datareader._utils import RemoteDataError
+import pandas_datareader.data as web
 
 pytestmark = pytest.mark.stable
 

--- a/pandas_datareader/tests/test_iex.py
+++ b/pandas_datareader/tests/test_iex.py
@@ -1,11 +1,16 @@
 from datetime import datetime
 
-import pytest
 from pandas import DataFrame
+import pytest
 
-from pandas_datareader.data import (DataReader, get_summary_iex, get_last_iex,
-                                    get_dailysummary_iex, get_iex_symbols,
-                                    get_iex_book)
+from pandas_datareader.data import (
+    DataReader,
+    get_dailysummary_iex,
+    get_iex_book,
+    get_iex_symbols,
+    get_last_iex,
+    get_summary_iex,
+)
 from pandas_datareader.exceptions import UnstableAPIWarning
 
 

--- a/pandas_datareader/tests/test_iex_daily.py
+++ b/pandas_datareader/tests/test_iex_daily.py
@@ -1,13 +1,12 @@
 from datetime import date, datetime, timedelta
-
 import os
 
 from pandas import DataFrame, MultiIndex
-
 import pytest
 
 import pandas_datareader.data as web
 from pandas_datareader.iex.daily import IEXDailyReader
+
 
 @pytest.mark.skipif(os.getenv("IEX_SANDBOX") != 'enable',
                     reason='All tests must be run in sandbox mode')

--- a/pandas_datareader/tests/test_moex.py
+++ b/pandas_datareader/tests/test_moex.py
@@ -1,6 +1,6 @@
 import pytest
-
 from requests.exceptions import HTTPError
+
 import pandas_datareader.data as web
 
 pytestmark = pytest.mark.stable

--- a/pandas_datareader/tests/test_nasdaq.py
+++ b/pandas_datareader/tests/test_nasdaq.py
@@ -1,6 +1,6 @@
-import pandas_datareader.data as web
-from pandas_datareader._utils import RemoteDataError
 from pandas_datareader._testing import skip_on_exception
+from pandas_datareader._utils import RemoteDataError
+import pandas_datareader.data as web
 
 
 class TestNasdaqSymbols(object):

--- a/pandas_datareader/tests/test_oecd.py
+++ b/pandas_datareader/tests/test_oecd.py
@@ -5,8 +5,8 @@ import pandas as pd
 import pandas.util.testing as tm
 import pytest
 
-import pandas_datareader.data as web
 from pandas_datareader._utils import RemoteDataError
+import pandas_datareader.data as web
 
 
 class TestOECD(object):

--- a/pandas_datareader/tests/test_quandl.py
+++ b/pandas_datareader/tests/test_quandl.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 
-import pandas_datareader.data as web
 from pandas_datareader.compat import assert_frame_equal
+import pandas_datareader.data as web
 
 pytestmark = pytest.mark.requires_api_key
 

--- a/pandas_datareader/tests/test_robinhood.py
+++ b/pandas_datareader/tests/test_robinhood.py
@@ -2,8 +2,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandas_datareader.robinhood import RobinhoodQuoteReader, \
-    RobinhoodHistoricalReader
+from pandas_datareader.robinhood import (
+    RobinhoodHistoricalReader,
+    RobinhoodQuoteReader,
+)
 
 syms = ['GOOG', ['GOOG', 'AAPL']]
 ids = list(map(str, syms))

--- a/pandas_datareader/tests/test_tiingo.py
+++ b/pandas_datareader/tests/test_tiingo.py
@@ -4,8 +4,13 @@ import pandas as pd
 import pytest
 
 from pandas_datareader.compat import PY3
-from pandas_datareader.tiingo import TiingoDailyReader, TiingoMetaDataReader, \
-    TiingoQuoteReader, TiingoIEXHistoricalReader, get_tiingo_symbols
+from pandas_datareader.tiingo import (
+    TiingoDailyReader,
+    TiingoIEXHistoricalReader,
+    TiingoMetaDataReader,
+    TiingoQuoteReader,
+    get_tiingo_symbols,
+)
 
 pytestmark = pytest.mark.requires_api_key
 

--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -6,11 +6,16 @@ import pandas.util.testing as tm
 import pytest
 import requests
 
-from pandas_datareader.compat import assert_raises_regex
-from pandas_datareader.wb import (search, download, get_countries,
-                                  get_indicators, WorldBankReader)
-from pandas_datareader._utils import RemoteDataError
 from pandas_datareader._testing import skip_on_exception
+from pandas_datareader._utils import RemoteDataError
+from pandas_datareader.compat import assert_raises_regex
+from pandas_datareader.wb import (
+    WorldBankReader,
+    download,
+    get_countries,
+    get_indicators,
+    search,
+)
 
 
 class TestWB(object):

--- a/pandas_datareader/tests/yahoo/test_options.py
+++ b/pandas_datareader/tests/yahoo/test_options.py
@@ -1,11 +1,10 @@
-import os
 from datetime import datetime
+import os
 
 import numpy as np
 import pandas as pd
-
-import pytest
 import pandas.util.testing as tm
+import pytest
 
 import pandas_datareader.data as web
 

--- a/pandas_datareader/tests/yahoo/test_yahoo.py
+++ b/pandas_datareader/tests/yahoo/test_yahoo.py
@@ -1,17 +1,17 @@
 from datetime import datetime
-import requests
 
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-from requests.exceptions import ConnectionError
-import pytest
 import pandas.util.testing as tm
+import pytest
+import requests
+from requests.exceptions import ConnectionError
 
+from pandas_datareader._testing import skip_on_exception
+from pandas_datareader._utils import RemoteDataError
 import pandas_datareader.data as web
 from pandas_datareader.data import YahooDailyReader
-from pandas_datareader._utils import RemoteDataError
-from pandas_datareader._testing import skip_on_exception
 
 XFAIL_REASON = 'Known connection failures on Yahoo when testing!'
 

--- a/pandas_datareader/wb.py
+++ b/pandas_datareader/wb.py
@@ -2,11 +2,11 @@
 
 import warnings
 
-from pandas_datareader.compat import reduce, lrange, string_types
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from pandas_datareader.base import _BaseReader
+from pandas_datareader.compat import lrange, reduce, string_types
 
 # This list of country codes was pulled from wikipedia during October 2014.
 # While some exceptions do exist, it is the best proxy for countries supported

--- a/pandas_datareader/yahoo/components.py
+++ b/pandas_datareader/yahoo/components.py
@@ -1,8 +1,10 @@
 from pandas import DataFrame
 from pandas.io.common import urlopen
 
-from pandas_datareader.exceptions import ImmediateDeprecationError, \
-    DEP_ERROR_MSG
+from pandas_datareader.exceptions import (
+    DEP_ERROR_MSG,
+    ImmediateDeprecationError,
+)
 
 _URL = 'http://download.finance.yahoo.com/d/quotes.csv?'
 

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -3,7 +3,9 @@ from __future__ import division
 import json
 import re
 import time
-from pandas import (DataFrame, to_datetime, notnull, isnull)
+
+from pandas import DataFrame, isnull, notnull, to_datetime
+
 from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.base import _DailyBaseReader
 

--- a/pandas_datareader/yahoo/fx.py
+++ b/pandas_datareader/yahoo/fx.py
@@ -1,10 +1,12 @@
-import time
 import json
+import time
 import warnings
-from pandas import (DataFrame, Series, to_datetime, concat)
-from pandas_datareader.yahoo.daily import YahooDailyReader
-from pandas_datareader._utils import (RemoteDataError, SymbolWarning)
+
+from pandas import DataFrame, Series, concat, to_datetime
+
+from pandas_datareader._utils import RemoteDataError, SymbolWarning
 from pandas_datareader.compat import string_types
+from pandas_datareader.yahoo.daily import YahooDailyReader
 
 
 class YahooFXReader(YahooDailyReader):

--- a/pandas_datareader/yahoo/options.py
+++ b/pandas_datareader/yahoo/options.py
@@ -1,13 +1,18 @@
-import warnings
 import datetime as dt
-import numpy as np
 import json
+import warnings
 
-from pandas import to_datetime
-from pandas import concat, DatetimeIndex, Series, MultiIndex
+import numpy as np
+from pandas import (
+    DataFrame,
+    DatetimeIndex,
+    MultiIndex,
+    Series,
+    concat,
+    to_datetime,
+)
 from pandas.io.json import read_json
 from pandas.tseries.offsets import MonthEnd
-from pandas import DataFrame
 
 from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.base import _OptionBaseReader

--- a/pandas_datareader/yahoo/quotes.py
+++ b/pandas_datareader/yahoo/quotes.py
@@ -1,5 +1,6 @@
-import json
 from collections import OrderedDict
+import json
+
 from pandas import DataFrame
 
 from pandas_datareader.base import _BaseReader

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,13 @@ known_compat=pandas_datareader.compat.*
 sections=FUTURE,COMPAT,STDLIB,THIRDPARTY,PRE_CORE,FIRSTPARTY,LOCALFOLDER
 known_first_party=pandas_datareader
 known_third_party=numpy,pandas,pytest,requests
-multi_line_output=0
+multi_line_output=3
 force_grid_wrap=0
+use_parentheses=True
+include_trailing_comma=True
 combine_as_imports=True
 force_sort_within_sections=True
-line_width=99
+line_width=88
 
 [tool:pytest]
 # sync minversion with setup.cfg & install.rst


### PR DESCRIPTION
Use isort to improve import consistency

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
