### PR TITLE
Update WorldBank indicator format

### DIFF
--- a/pandas_datareader/tests/test_wb.py
+++ b/pandas_datareader/tests/test_wb.py
@@ -216,8 +216,8 @@ class TestWB(object):
         result4 = WorldBankReader(session=session).get_indicators()
 
         for result in [result1, result2, result3, result4]:
-            exp_col = pd.Index(['id', 'name', 'source', 'sourceNote',
-                                'sourceOrganization', 'topics', 'unit'])
+            exp_col = pd.Index(['id', 'name', 'unit', 'source', 'sourceNote',
+                                'sourceOrganization', 'topics'])
             # assert_index_equal doesn't exists
             assert result.columns.equals(exp_col)
             assert len(result) > 10000


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

Correcting https://travis-ci.org/pydata/pandas-datareader/jobs/585837426

```
    def test_wdi_get_indicators(self):
        result1 = get_indicators()
        result2 = WorldBankReader().get_indicators()
        session = requests.Session()
        result3 = get_indicators(session=session)
        result4 = WorldBankReader(session=session).get_indicators()
        for result in [result1, result2, result3, result4]:
            exp_col = pd.Index(['id', 'name', 'source', 'sourceNote',
                                'sourceOrganization', 'topics', 'unit'])
            # assert_index_equal doesn't exists
>           assert result.columns.equals(exp_col)
E           AssertionError: assert False
E            +  where False = <bound method Index.equals of Index(['id', 'name', 'unit', 'source', 'sourceNote', 'sourceOrganization',\n       'topics'],\n      dtype='object')>(Index(['id', 'name', 'source', 'sourceNote', 'sourceOrganization', 'topics',\n       'unit'],\n      dtype='object'))
E            +    where <bound method Index.equals of Index(['id', 'name', 'unit', 'source', 'sourceNote', 'sourceOrganization',\n       'topics'],\n      dtype='object')> = Index(['id', 'name', 'unit', 'source', 'sourceNote', 'sourceOrganization',\n       'topics'],\n      dtype='object').equals
E            +      where Index(['id', 'name', 'unit', 'source', 'sourceNote', 'sourceOrganization',\n       'topics'],\n      dtype='object') =                                id  ...                     topics\n0              1.0.HCount.1.90usd  ...              ...                           \n17015  s_policyholders_B2_nonlife  ...                           \n\n[17016 rows x 7 columns].columns
pandas_datareader/tests/test_wb.py:222: AssertionError
```

https://api.worldbank.org/v2/indicators?par_page=5000&format=json