### PR TITLE
MAINT: Deprecate access_key

### DIFF
--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -158,7 +158,7 @@ symbols. The following endpoints are available:
 
     In [4]: f = web.DataReader("AAPL", "av-daily", start=datetime(2017, 2, 9),
        ...:                    end=datetime(2017, 5, 24),
-       ...:                    access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+       ...:                    api_key=os.getenv('ALPHAVANTAGE_API_KEY'))
 
     In [5]: f.loc["2017-02-09"]
     Out[5]:
@@ -218,7 +218,7 @@ as "FROM/TO" as in "USD/JPY".
     In [2]: import pandas_datareader.data as web
 
     In [3]: f = web.DataReader("USD/JPY", "av-forex",
-        ...:                    access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+        ...:                    api_key=os.getenv('ALPHAVANTAGE_API_KEY'))
 
     In [4]: f
     Out[4]:
@@ -243,7 +243,7 @@ Multiple pairs are are allowable:
     In [2]: import pandas_datareader.data as web
 
     In [3]: f = web.DataReader(["USD/JPY", "BTC/CNY"], "av-forex",
-       ...:                    access_key=os.getenv('ALPHAVANTAGE_API_KEY'))
+       ...:                    api_key=os.getenv('ALPHAVANTAGE_API_KEY'))
 
 
     In [4]: f

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -6,6 +6,8 @@ Module contains tools for collecting data from various remote sources
 
 import warnings
 
+from pandas.util._decorators import deprecate_kwarg
+
 from pandas_datareader.av.forex import AVForexReader
 from pandas_datareader.av.quotes import AVQuotesReader
 from pandas_datareader.av.sector import AVSectorPerformanceReader
@@ -264,6 +266,7 @@ def get_iex_book(*args, **kwargs):
     return IEXDeep(*args, **kwargs).read()
 
 
+@deprecate_kwarg("access_key", "api_key")
 def DataReader(
     name,
     data_source=None,
@@ -272,7 +275,7 @@ def DataReader(
     retry_count=3,
     pause=0.1,
     session=None,
-    access_key=None,
+    api_key=None,
 ):
     """
     Imports data from a number of online sources.
@@ -298,7 +301,7 @@ def DataReader(
         single value given for symbol, represents the pause between retries.
     session : Session, default None
         requests.sessions.Session instance to be used
-    access_key : (str, None)
+    api_key : (str, None)
         Optional parameter to specify an API key for certain data sources.
 
     Examples
@@ -376,7 +379,7 @@ def DataReader(
             start=start,
             end=end,
             chunksize=25,
-            api_key=access_key,
+            api_key=api_key,
             retry_count=retry_count,
             pause=pause,
             session=session,
@@ -432,7 +435,7 @@ def DataReader(
         ).read()
 
     elif data_source == "enigma":
-        return EnigmaReader(dataset_id=name, api_key=access_key).read()
+        return EnigmaReader(dataset_id=name, api_key=api_key).read()
 
     elif data_source == "fred":
         return FredReader(
@@ -487,7 +490,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
     elif data_source == "moex":
         return MoexReader(
@@ -515,7 +518,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "yahoo-actions":
@@ -547,7 +550,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-daily":
@@ -559,7 +562,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-daily-adjusted":
@@ -571,7 +574,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-weekly":
@@ -583,7 +586,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-weekly-adjusted":
@@ -595,7 +598,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-monthly":
@@ -607,7 +610,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-monthly-adjusted":
@@ -619,7 +622,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "av-intraday":
@@ -631,7 +634,7 @@ def DataReader(
             retry_count=retry_count,
             pause=pause,
             session=session,
-            api_key=access_key,
+            api_key=api_key,
         ).read()
 
     elif data_source == "econdb":

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -28,7 +28,7 @@ class TestEnigma(object):
 
     def test_enigma_datareader(self):
         try:
-            df = web.DataReader(self.dataset_id, "enigma", access_key=TEST_API_KEY)
+            df = web.DataReader(self.dataset_id, "enigma", api_key=TEST_API_KEY)
             assert "case_number" in df.columns
         except HTTPError as e:
             pytest.skip(e)
@@ -42,10 +42,10 @@ class TestEnigma(object):
 
     def test_bad_key(self):
         with pytest.raises(HTTPError):
-            web.DataReader(self.dataset_id, "enigma", access_key=TEST_API_KEY + "xxx")
+            web.DataReader(self.dataset_id, "enigma", api_key=TEST_API_KEY + "xxx")
 
     def test_bad_dataset_id(self):
         with pytest.raises(HTTPError):
             web.DataReader(
-                "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzz", "enigma", access_key=TEST_API_KEY
+                "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzz", "enigma", api_key=TEST_API_KEY
             )

--- a/pandas_datareader/tests/test_quandl.py
+++ b/pandas_datareader/tests/test_quandl.py
@@ -32,7 +32,7 @@ class TestQuandl(object):
 
     def test_db_wiki_us(self):
         df = web.DataReader(
-            "F", "quandl", self.start10, self.end10, access_key=TEST_API_KEY
+            "F", "quandl", self.start10, self.end10, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,
@@ -56,7 +56,7 @@ class TestQuandl(object):
     def test_db_fse_frankfurt(self):
         # ALV_X: Allianz SE
         df = web.DataReader(
-            "FSE/ALV_X", "quandl", self.start10, self.end10, access_key=TEST_API_KEY
+            "FSE/ALV_X", "quandl", self.start10, self.end10, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,
@@ -78,7 +78,7 @@ class TestQuandl(object):
     def test_fse_eon(self):
         # EON_X: E.on Se
         df = web.DataReader(
-            "FSE/EON_X", "quandl", self.start2, self.end2, access_key=TEST_API_KEY
+            "FSE/EON_X", "quandl", self.start2, self.end2, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,
@@ -102,7 +102,7 @@ class TestQuandl(object):
         # as of 2017-06-11, some datasets end a few months after their start,
         # e.g. ALVD, BASD
         df = web.DataReader(
-            "EURONEXT/FP", "quandl", self.start2, self.end2, access_key=TEST_API_KEY
+            "EURONEXT/FP", "quandl", self.start2, self.end2, api_key=TEST_API_KEY
         )
         self.check_headers(df, ["Open", "High", "Low", "Last", "Turnover", "Volume"])
         assert df.Last.at[self.day2] == 42.525
@@ -112,7 +112,7 @@ class TestQuandl(object):
     def test_hk_hsbc_uk(self):
         # 00005: HSBC
         df = web.DataReader(
-            "HKEX/00005", "quandl", self.start2, self.end2, access_key=TEST_API_KEY
+            "HKEX/00005", "quandl", self.start2, self.end2, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,
@@ -137,7 +137,7 @@ class TestQuandl(object):
     def test_db_nse_in(self):
         # TCS: Tata Consutancy Services
         df = web.DataReader(
-            "NSE/TCS", "quandl", self.start10, self.end10, access_key=TEST_API_KEY
+            "NSE/TCS", "quandl", self.start10, self.end10, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,
@@ -156,7 +156,7 @@ class TestQuandl(object):
     def test_db_tse_jp(self):
         # TSE/6758: Sony Corp.
         df = web.DataReader(
-            "TSE/6758", "quandl", self.start10, self.end10, access_key=TEST_API_KEY
+            "TSE/6758", "quandl", self.start10, self.end10, api_key=TEST_API_KEY
         )
         self.check_headers(df, ["Open", "High", "Low", "Close", "Volume"])
         assert df.Close.at[self.day10] == 5190.0
@@ -169,7 +169,7 @@ class TestQuandl(object):
     def test_db_hkex_cn(self):
         # HKEX/00941: China Mobile
         df = web.DataReader(
-            "HKEX/00941", "quandl", self.start2, self.end2, access_key=TEST_API_KEY
+            "HKEX/00941", "quandl", self.start2, self.end2, api_key=TEST_API_KEY
         )
         self.check_headers(
             df,


### PR DESCRIPTION
Use a decorator to deprecate access_key

closes #692

- [X] closes #692
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] passes `black --check pandas_datareader`

