### PR TITLE
Update docstring as iso_code is not returned for WorldBank

### DIFF
--- a/pandas_datareader/wb.py
+++ b/pandas_datareader/wb.py
@@ -856,7 +856,7 @@ def download(
     Returns
     -------
     data : DataFrame
-        DataFrame with columns country, iso_code, year, indicator value
+        DataFrame with columns country, year, indicator value
     """
     return WorldBankReader(
         symbols=indicator,


### PR DESCRIPTION
- [x] closes #57

```
from pandas_datareader import wb
>>> pandas_datareader.__version__
'0.8.0'
>>> ind = ['NY.GDP.PCAP.KD', 'IT.MOB.COV.ZS']
>>> dat = wb.download(indicator=ind, country='all', start=2015, end=2015).dropna()
/home/jovyan/.local/lib/python3.7/site-packages/pandas_datareader/wb.py:659: UserWarning: No results found from world bank. Indicator: IT.MOB.COV.ZS
  warnings.warn(msg)
>>> dat
                                     NY.GDP.PCAP.KD
country                        year                
Arab World                     2015     6430.464609
Caribbean small states         2015     9224.146707
Central Europe and the Baltics 2015    14327.577261
Early-demographic dividend     2015     3400.049930
East Asia & Pacific            2015     9227.673906
...                                             ...
Virgin Islands (U.S.)          2015    29408.055125
West Bank and Gaza             2015     2631.811985
Yemen, Rep.                    2015      908.757846
Zambia                         2015     1641.005482
Zimbabwe                       2015     1234.103352

[244 rows x 1 columns]
```
