### PR TITLE
Daily historical data from Naver Finance

### DIFF
--- a/docs/source/readers/index.rst
+++ b/docs/source/readers/index.rst
@@ -14,6 +14,7 @@ Data Readers
    iex
    moex
    nasdaq-trader
+   naver
    oecd
    quandl
    stooq

--- a/docs/source/readers/naver.rst
+++ b/docs/source/readers/naver.rst
@@ -1,0 +1,8 @@
+Naver Finance
+-------------
+
+.. py:module:: pandas_datareader.naver
+
+.. autoclass:: NaverDailyReader
+   :members:
+   :inherited-members: read

--- a/docs/source/remote_data.rst
+++ b/docs/source/remote_data.rst
@@ -45,6 +45,7 @@ Currently the following sources are supported:
     - :ref:`Nasdaq Trader symbol definitions<remote_data.nasdaq_symbols>`
     - :ref:`Stooq<remote_data.stooq>`
     - :ref:`MOEX<remote_data.moex>`
+    - :ref:`Naver Finance<remote_data.naver>`
 
 It should be noted, that various sources support different kinds of data, so not all sources implement the same methods and the data elements returned might also differ.
 
@@ -686,3 +687,19 @@ The Moscow Exchange (MOEX) provides historical data.
    import pandas_datareader.data as web
    f = web.DataReader('USD000UTSTOM', 'moex', start='2017-07-01', end='2017-07-31')
    f.head()
+
+.. _remote_data.naver:
+
+Naver Finance Data
+==================
+`Naver Finance <https://finance.naver.com>`_ provides Korean stock market
+(`KOSPI`_, `KOSDAQ`_) historical data.
+
+.. ipython:: python
+
+   import pandas_datareader.data as web
+   df = web.DataReader('005930', 'naver', start='2019-09-10', end='2019-10-09')
+   df.head()
+
+.. _KOSPI: https://en.wikipedia.org/wiki/KOSPI
+.. _KOSDAQ: https://en.wikipedia.org/wiki/KOSDAQ

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -39,6 +39,8 @@ from pandas_datareader.yahoo.daily import YahooDailyReader
 from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.yahoo.quotes import YahooQuotesReader
 
+from pandas_datareader.naver import NaverDailyReader
+
 __all__ = [
     "get_components_yahoo",
     "get_data_enigma",
@@ -369,6 +371,7 @@ def DataReader(
         "av-monthly-adjusted",
         "av-intraday",
         "econdb",
+        "naver",
     ]
 
     if data_source not in expected_source:
@@ -653,6 +656,16 @@ def DataReader(
 
     elif data_source == "econdb":
         return EcondbReader(
+            symbols=name,
+            start=start,
+            end=end,
+            retry_count=retry_count,
+            pause=pause,
+            session=session,
+        ).read()
+
+    elif data_source == "naver":
+        return NaverDailyReader(
             symbols=name,
             start=start,
             end=end,

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -24,6 +24,7 @@ from pandas_datareader.iex.deep import Deep as IEXDeep
 from pandas_datareader.iex.tops import LastReader as IEXLasts, TopsReader as IEXTops
 from pandas_datareader.moex import MoexReader
 from pandas_datareader.nasdaq_trader import get_nasdaq_symbols
+from pandas_datareader.naver import NaverDailyReader
 from pandas_datareader.oecd import OECDReader
 from pandas_datareader.quandl import QuandlReader
 from pandas_datareader.robinhood import RobinhoodHistoricalReader, RobinhoodQuoteReader
@@ -39,7 +40,6 @@ from pandas_datareader.yahoo.daily import YahooDailyReader
 from pandas_datareader.yahoo.options import Options as YahooOptions
 from pandas_datareader.yahoo.quotes import YahooQuotesReader
 
-from pandas_datareader.naver import NaverDailyReader
 
 __all__ = [
     "get_components_yahoo",

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -8,6 +8,13 @@ from six import string_types
 
 
 class NaverDailyReader(_DailyBaseReader):
+    """Fetches daily historical data from Naver Finance.
+
+    :param symbols: A single symbol; multiple symbols are not currently supported.
+    :param adjust_price: Not implemented
+    :param interval: Not implemented
+    :param adjust_dividends: Not implemented
+    """
     def __init__(
         self,
         symbols=None,

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -54,10 +54,10 @@ class NaverDailyReader(_DailyBaseReader):
 
     def _get_params(self, symbol):
         # NOTE: The server does not take start, end dates as inputs; it only
-        # takes the number of past days as an input. To circumvent this
+        # takes the number of trading days as an input. To circumvent this
         # pitfall, we calculate the number of business days between self.start
-        # and the current date. And then before returning the final result
-        # (from _read_one_data()) we filter by self.end.
+        # and the current date. And then we filter by self.end before returning
+        # the final result (in _read_one_data()).
         days = np.busday_count(self.start.date(), datetime.now().date())
         params = {"symbol": symbol, "timeframe": "day", "count": days, "requestType": 0}
         return params

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -33,8 +33,8 @@ class NaverDailyReader(_DailyBaseReader):
 
         self.headers = {
             "Sec-Fetch-Mode": "no-cors",
-            "Referer": "https://finance.naver.com/item/fchart.nhn?code={}".format(symbols),
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+            "Referer": "https://finance.naver.com/item/fchart.nhn?code={}".format(symbols),  # noqa
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",  # noqa
         }
 
     @property
@@ -61,7 +61,8 @@ class NaverDailyReader(_DailyBaseReader):
         """
         resp = self._get_response(url, params=params)
         parsed = self._parse_xml_response(resp.text)
-        prices = DataFrame(parsed, columns=['Date', 'Open', 'High', 'Low', 'Close', 'Volume'])
+        prices = DataFrame(
+            parsed, columns=['Date', 'Open', 'High', 'Low', 'Close', 'Volume'])
         prices["Date"] = to_datetime(prices["Date"])
 
         return prices
@@ -73,7 +74,8 @@ class NaverDailyReader(_DailyBaseReader):
 
             <?xml version="1.0" encoding="EUC-KR" ?>
             <protocol>
-                <chartdata symbol="005930" name="삼성전자" count="500" timeframe="day" precision="0" origintime="19900103">
+                <chartdata symbol="005930" name="삼성전자" count="500"
+                        timeframe="day" precision="0" origintime="19900103">
                     <item data="20170918|218500|222000|217000|220500|72124" />
                     <item data="20170919|218000|221000|217500|219000|62753" />
                     ...

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -1,0 +1,56 @@
+from pandas_datareader.base import _DailyBaseReader
+
+class NaverDailyReader(_DailyBaseReader):
+
+    def __init__(
+        self,
+        symbols=None,
+        start=None,
+        end=None,
+        retry_count=3,
+        pause=0.1,
+        session=None,
+        adjust_price=False,
+        ret_index=False,
+        chunksize=1,
+        interval="d",
+        get_actions=False,
+        adjust_dividends=True,
+    ):
+        super(NaverDailyReader, self).__init__(
+            symbols=symbols,
+            start=start,
+            end=end,
+            retry_count=retry_count,
+            pause=pause,
+            session=session,
+            chunksize=chunksize,
+        )
+
+        self.headers = {
+            "Sec-Fetch-Mode": "no-cors",
+            "Referer": "https://finance.naver.com/item/fchart.nhn?code={}".format(symbols),
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+        }
+
+    @property
+    def get_actions(self):
+        return self._get_actions
+
+    @property
+    def url(self):
+        return "https://fchart.stock.naver.com/sise.nhn"
+
+    def _get_params(self, symbol):
+        params = {
+            "symbol": symbol,
+            "timeframe": "day",
+            "count": 500,
+            "requestType": 0,
+        }
+        return params
+
+    def _read_one_data(self, url, params):
+        """Read one data from specified symbol"""
+        resp = self._get_response(url, params=params)
+        return resp

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -1,3 +1,6 @@
+from xml.etree import ElementTree
+
+from pandas import DataFrame
 from pandas_datareader.base import _DailyBaseReader
 
 class NaverDailyReader(_DailyBaseReader):
@@ -51,6 +54,31 @@ class NaverDailyReader(_DailyBaseReader):
         return params
 
     def _read_one_data(self, url, params):
-        """Read one data from specified symbol"""
+        """Read one data from specified symbol.
+
+        :rtype: DataFrame
+        """
         resp = self._get_response(url, params=params)
-        return resp
+        parsed = self._parse_xml_response(resp.text)
+        prices = DataFrame(parsed, columns=['Date', 'Open', 'High', 'Low', 'Close', 'Volume'])
+
+        return prices
+
+    def _parse_xml_response(self, xml_content):
+        """Parses XML response from the server.
+
+        An example of response:
+
+            <?xml version="1.0" encoding="EUC-KR" ?>
+            <protocol>
+                <chartdata symbol="005930" name="삼성전자" count="500" timeframe="day" precision="0" origintime="19900103">
+                    <item data="20170918|218500|222000|217000|220500|72124" />
+                    <item data="20170919|218000|221000|217500|219000|62753" />
+                    ...
+            </protocol>
+        """
+        root = ElementTree.fromstring(xml_content)
+        items = root.findall("chartdata/item")
+
+        for item in items:
+            yield item.attrib["data"].split("|")

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -74,7 +74,7 @@ class NaverDailyReader(_DailyBaseReader):
 
             <?xml version="1.0" encoding="EUC-KR" ?>
             <protocol>
-                <chartdata symbol="005930" name="삼성전자" count="500"
+                <chartdata symbol="005930" name="Samsung Elctronics" count="500"
                         timeframe="day" precision="0" origintime="19900103">
                     <item data="20170918|218500|222000|217000|220500|72124" />
                     <item data="20170919|218000|221000|217500|219000|62753" />

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -5,7 +5,6 @@ from pandas_datareader.base import _DailyBaseReader
 
 
 class NaverDailyReader(_DailyBaseReader):
-
     def __init__(
         self,
         symbols=None,
@@ -33,7 +32,9 @@ class NaverDailyReader(_DailyBaseReader):
 
         self.headers = {
             "Sec-Fetch-Mode": "no-cors",
-            "Referer": "https://finance.naver.com/item/fchart.nhn?code={}".format(symbols),  # noqa
+            "Referer": "https://finance.naver.com/item/fchart.nhn?code={}".format(
+                symbols
+            ),
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",  # noqa
         }
 
@@ -46,12 +47,7 @@ class NaverDailyReader(_DailyBaseReader):
         return "https://fchart.stock.naver.com/sise.nhn"
 
     def _get_params(self, symbol):
-        params = {
-            "symbol": symbol,
-            "timeframe": "day",
-            "count": 500,
-            "requestType": 0,
-        }
+        params = {"symbol": symbol, "timeframe": "day", "count": 500, "requestType": 0}
         return params
 
     def _read_one_data(self, url, params):
@@ -62,7 +58,8 @@ class NaverDailyReader(_DailyBaseReader):
         resp = self._get_response(url, params=params)
         parsed = self._parse_xml_response(resp.text)
         prices = DataFrame(
-            parsed, columns=['Date', 'Open', 'High', 'Low', 'Close', 'Volume'])
+            parsed, columns=["Date", "Open", "High", "Low", "Close", "Volume"]
+        )
         prices["Date"] = to_datetime(prices["Date"])
 
         return prices

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -15,6 +15,7 @@ class NaverDailyReader(_DailyBaseReader):
     :param interval: Not implemented
     :param adjust_dividends: Not implemented
     """
+
     def __init__(
         self,
         symbols=None,
@@ -80,9 +81,10 @@ class NaverDailyReader(_DailyBaseReader):
             parsed, columns=["Date", "Open", "High", "Low", "Close", "Volume"]
         )
         prices["Date"] = to_datetime(prices["Date"])
+        prices = prices.set_index("Date")
 
         # NOTE: See _get_params() for explanations.
-        return prices[(prices["Date"] >= self.start) & (prices["Date"] <= self.end)]
+        return prices[(prices.index >= self.start) & (prices.index <= self.end)]
 
     def _parse_xml_response(self, xml_content):
         """Parses XML response from the server.

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -1,7 +1,8 @@
 from xml.etree import ElementTree
 
-from pandas import DataFrame
+from pandas import DataFrame, to_datetime
 from pandas_datareader.base import _DailyBaseReader
+
 
 class NaverDailyReader(_DailyBaseReader):
 
@@ -61,6 +62,7 @@ class NaverDailyReader(_DailyBaseReader):
         resp = self._get_response(url, params=params)
         parsed = self._parse_xml_response(resp.text)
         prices = DataFrame(parsed, columns=['Date', 'Open', 'High', 'Low', 'Close', 'Volume'])
+        prices["Date"] = to_datetime(prices["Date"])
 
         return prices
 

--- a/pandas_datareader/naver.py
+++ b/pandas_datareader/naver.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 import numpy as np
 from pandas import DataFrame, to_datetime
 from pandas_datareader.base import _DailyBaseReader
+from six import string_types
 
 
 class NaverDailyReader(_DailyBaseReader):
@@ -22,6 +23,9 @@ class NaverDailyReader(_DailyBaseReader):
         get_actions=False,
         adjust_dividends=True,
     ):
+        if not isinstance(symbols, string_types):
+            raise NotImplementedError("Bulk-fetching is not implemented")
+
         super(NaverDailyReader, self).__init__(
             symbols=symbols,
             start=start,

--- a/pandas_datareader/tests/test_naver.py
+++ b/pandas_datareader/tests/test_naver.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from pandas_datareader import DataReader
+import pytest
+
+
+class TestNaver(object):
+    @pytest.mark.parametrize(
+        "symbol, start, end",
+        [
+            ("005930", (2019, 10, 1), (2019, 10, 7)),
+            ("000660", (2018, 1, 1), (2018, 12, 31)),
+            ("069500", (2017, 6, 3), (2018, 9, 9)),
+        ],
+    )
+    def test_naver_daily_reader(self, symbol, start, end):
+        start = datetime(*start)
+        end = datetime(*end)
+        reader = DataReader(symbol, "naver", start, end)
+
+        assert reader.shape[1] == 6
+        assert reader["Date"].min() >= start
+        assert reader["Date"].max() <= end

--- a/pandas_datareader/tests/test_naver.py
+++ b/pandas_datareader/tests/test_naver.py
@@ -18,9 +18,9 @@ class TestNaver(object):
         end = datetime(*end)
         reader = DataReader(symbol, "naver", start, end)
 
-        assert reader.shape[1] == 6
-        assert reader["Date"].min() >= start
-        assert reader["Date"].max() <= end
+        assert reader.shape[1] == 5
+        assert reader.index.min() >= start
+        assert reader.index.max() <= end
 
     def test_bulk_fetch(self):
         with pytest.raises(NotImplementedError):

--- a/pandas_datareader/tests/test_naver.py
+++ b/pandas_datareader/tests/test_naver.py
@@ -21,3 +21,7 @@ class TestNaver(object):
         assert reader.shape[1] == 6
         assert reader["Date"].min() >= start
         assert reader["Date"].max() <= end
+
+    def test_bulk_fetch(self):
+        with pytest.raises(NotImplementedError):
+            DataReader(["005930", "000660"])


### PR DESCRIPTION
This PR adds abilities to fetch daily historical data from [Naver Finance](https://finance.naver.com), which serves Korean (KOSPI, KOSDAQ) market data.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
