### PR TITLE
update documentation for start date

### DIFF
--- a/pandas_datareader/tiingo.py
+++ b/pandas_datareader/tiingo.py
@@ -143,7 +143,7 @@ class TiingoDailyReader(_BaseReader):
     start : string, int, date, datetime, Timestamp
         Starting date, timestamp. Parses many different kind of date
         representations (e.g., 'JAN-01-2010', '1/1/10', 'Jan, 1, 1980').
-        Default is '1/1/2010'.
+        Default starting date is 5 years before current date.
     end : string, int, date, datetime, Timestamp
         Ending date, timestamp. Same format as starting date.
     retry_count : int, default 3


### PR DESCRIPTION
default_start_date in pandas_datareader/base.py is defined as 5 years before current date.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
