### PR TITLE
Empty DataFrame on bond yields

### DIFF
--- a/pandas_datareader/stooq.py
+++ b/pandas_datareader/stooq.py
@@ -55,6 +55,7 @@ class StooqDailyReader(_DailyBaseReader):
                     "uk",
                     "us",
                     "f",
+                    "b",
                 ]:
                     symbol = ".".join([symbol, "US"])
 


### PR DESCRIPTION
Hey guys, lately I found StooqDailyReader cause a problem when I try to download data series like "10AUY.B". Here is an example of stooq.com url for Australian bond yield. https://stooq.com/q/?s=10auy.b
Hope this help you people!

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
