### PR TITLE
MAINT: Deprecate Enigma

### DIFF
--- a/pandas_datareader/enigma.py
+++ b/pandas_datareader/enigma.py
@@ -5,6 +5,10 @@ import pandas as pd
 
 from pandas_datareader.base import _BaseReader, string_types
 from pandas_datareader.compat import StringIO
+from pandas_datareader.exceptions import (
+    DEP_ERROR_MSG,
+    ImmediateDeprecationError,
+)
 
 
 class EnigmaReader(_BaseReader):
@@ -52,6 +56,7 @@ class EnigmaReader(_BaseReader):
         session=None,
         base_url="https://public.enigma.com/api",
     ):
+        raise ImmediateDeprecationError(DEP_ERROR_MSG.format("Enigma"))
 
         super(EnigmaReader, self).__init__(
             symbols=[], retry_count=retry_count, pause=pause, session=session

--- a/pandas_datareader/tests/test_enigma.py
+++ b/pandas_datareader/tests/test_enigma.py
@@ -1,17 +1,15 @@
-import os
-
 import pytest
 from requests.exceptions import HTTPError
 
 import pandas_datareader as pdr
 import pandas_datareader.data as web
+from pandas_datareader.exceptions import ImmediateDeprecationError
 
 pytestmark = pytest.mark.requires_api_key
 
-TEST_API_KEY = os.getenv("ENIGMA_API_KEY")
+TEST_API_KEY = "DEPRECATED"
 
 
-@pytest.mark.skipif(TEST_API_KEY is None, reason="no enigma_api_key")
 class TestEnigma(object):
     @property
     def dataset_id(self):
@@ -28,24 +26,24 @@ class TestEnigma(object):
 
     def test_enigma_datareader(self):
         try:
-            df = web.DataReader(self.dataset_id, "enigma", api_key=TEST_API_KEY)
-            assert "case_number" in df.columns
+            with pytest.raises(ImmediateDeprecationError):
+                web.DataReader(self.dataset_id, "enigma", api_key=TEST_API_KEY)
         except HTTPError as e:
             pytest.skip(e)
 
     def test_enigma_get_data_enigma(self):
         try:
-            df = pdr.get_data_enigma(self.dataset_id, TEST_API_KEY)
-            assert "case_number" in df.columns
+            with pytest.raises(ImmediateDeprecationError):
+                pdr.get_data_enigma(self.dataset_id, TEST_API_KEY)
         except HTTPError as e:
             pytest.skip(e)
 
     def test_bad_key(self):
-        with pytest.raises(HTTPError):
+        with pytest.raises(ImmediateDeprecationError):
             web.DataReader(self.dataset_id, "enigma", api_key=TEST_API_KEY + "xxx")
 
     def test_bad_dataset_id(self):
-        with pytest.raises(HTTPError):
+        with pytest.raises(ImmediateDeprecationError):
             web.DataReader(
                 "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzz", "enigma", api_key=TEST_API_KEY
             )


### PR DESCRIPTION
Due to change in their business model Enigma is no longer working

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check pandas_datareader`
- [x] added entry to docs/source/whatsnew/vLATEST.txt
