### PR TITLE
Revise whatsnew/v0.9.0.txt

### DIFF
--- a/docs/source/whatsnew/v0.9.0.txt
+++ b/docs/source/whatsnew/v0.9.0.txt
@@ -19,6 +19,7 @@ Enhancements
 - Added a timeout parameter to prevent infinite hangs (:issue:`790`)
 - Added AlphaVantage endpoint to get historical currency exchange rates (:issue:`764`)
 - Improved logging when rate limited (:issue:`745`)
+- Added daily historical data from Naver Finance (:issue:`722`)
 
 .. _whatsnew_090.api_breaking:
 


### PR DESCRIPTION
Apparently #722 did not add an entry to `docs/source/whatsnew/vLATEST.txt`, so I would like to amend `whatsnew/v0.9.0.txt`, if possible.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
