### PR TITLE
Fixing tests for index.freq

### DIFF
--- a/pandas_datareader/tests/test_econdb.py
+++ b/pandas_datareader/tests/test_econdb.py
@@ -60,6 +60,7 @@ class TestEcondb(object):
             expected = pd.Series(
                 values, index=index, name="Total international arrivals"
             )
+            expected.index.freq = None
             tm.assert_series_equal(
                 df[label]["Tourism demand surveys"]["Total international arrivals"],
                 expected,

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -98,7 +98,7 @@ class TestEurostat(object):
         uk = pd.Series(uk_values, name=uk_name, index=idx)
 
         for expected in [ne, uk]:
-            expected.index.freq = None  # don't compare freq
+            expected.index.freq = None
             result = df[expected.name]
             tm.assert_series_equal(result, expected)
 

--- a/pandas_datareader/tests/test_eurostat.py
+++ b/pandas_datareader/tests/test_eurostat.py
@@ -98,6 +98,7 @@ class TestEurostat(object):
         uk = pd.Series(uk_values, name=uk_name, index=idx)
 
         for expected in [ne, uk]:
+            expected.index.freq = None  # don't compare freq
             result = df[expected.name]
             tm.assert_series_equal(result, expected)
 

--- a/pandas_datareader/tests/test_fred.py
+++ b/pandas_datareader/tests/test_fred.py
@@ -72,6 +72,7 @@ class TestFred(object):
             index=[pd.Timestamp("2010-01-01 00:00:00")],
         )
         expected.index.rename("DATE", inplace=True)
+        expected.index.freq = "MS"
         tm.assert_frame_equal(received, expected, check_less_precise=True)
 
     def test_fred_multi_bad_series(self):

--- a/pandas_datareader/tests/test_oecd.py
+++ b/pandas_datareader/tests/test_oecd.py
@@ -202,6 +202,7 @@ class TestOECD(object):
         index = pd.date_range("2008-01-01", "2012-01-01", freq="AS", name="Year")
         for label, values in [("Japan", jp), ("United States", us)]:
             expected = pd.Series(values, index=index, name="Tourism demand surveys")
+            expected.index.freq = None
             series = df[label]["Total international arrivals"]["Tourism demand surveys"]
             tm.assert_series_equal(series, expected)
 


### PR DESCRIPTION
Fixing tests.

pandas.testing.assert_series_equal now includes a default argument of [check_freq=True](https://github.com/pandas-dev/pandas/blob/master/pandas/_testing.py#L1217). With this new arg some of the tests are failing as the index.freq does not match in comparisons.

I've adjusted index.freq so that the tests pass. Another option is to use check_freq=False, but this argument is not available in earlier versions of pandas. Alternatively, we could inspect the function for the existence of check_freq and pass False if required. I considered changing index.freq to be the easiest option.

Thanks

