### PR TITLE
Fixed test_moex_stock_datareader

### DIFF
--- a/pandas_datareader/tests/test_moex.py
+++ b/pandas_datareader/tests/test_moex.py
@@ -21,7 +21,7 @@ class TestMoex(object):
             df = web.DataReader(
                 ["GAZP", "SIBN"], "moex", start="2019-12-26", end="2019-12-26"
             )
-            assert df.size == 74
+            assert len(df) == 2
         except HTTPError as e:
             pytest.skip(e)
 


### PR DESCRIPTION
It looks like extra columns are coming back from the api and causing the df.size assertion to fail. I've changed this to assert the number of rows == 2 for each of "GAZP", "SIBN".

Cheers