### PR TITLE
added tiingo csv response serialisation options

### DIFF
--- a/docs/source/whatsnew/v.0.9.1.txt
+++ b/docs/source/whatsnew/v.0.9.1.txt
@@ -19,8 +19,9 @@ Enhancements
 - Added read_all_boards() method for MOEX that returns data 
   from every trading board (ver. 0.9.0 behaviour)
 - Docs for MOEX reedited
+- Added CSV response serialisation for Tiingo APIs (:issue:`821`)
 
-.. _whatsnew_080.bug_fixes:
+.. _whatsnew_091.bug_fixes:
 
 Bug Fixes
 ~~~~~~~~~
@@ -30,3 +31,4 @@ Bug Fixes
 Contributors
 ~~~~~~~~~~~~
 - Dmitry Alekseev
+- Tomasz Chodakowski

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -111,11 +111,11 @@ class _BaseReader(object):
             raise NotImplementedError(self._format)
         return self._read_lines(out)
 
-    def _read_url_as_StringIO(self, url, params=None):
+    def _read_url_as_StringIO(self, url, params=None, headers=None):
         """
         Open url (and retry)
         """
-        response = self._get_response(url, params=params)
+        response = self._get_response(url, params=params, headers=headers)
         text = self._sanitize_response(response)
         out = StringIO()
         if len(text) == 0:

--- a/pandas_datareader/tests/test_tiingo.py
+++ b/pandas_datareader/tests/test_tiingo.py
@@ -83,7 +83,9 @@ def test_tiingo_no_api_key(symbols):
 
 
 @pytest.mark.skipif(
-    pd.__version__ == "0.19.2", reason="pandas 0.19.2 does not like this file format"
+    pd.__version__ == "0.19.2",
+    reason="pandas 0.19.2 does not like\
+         this file format",
 )
 def test_tiingo_stock_symbols():
     sym = get_tiingo_symbols()

--- a/pandas_datareader/tests/test_tiingo.py
+++ b/pandas_datareader/tests/test_tiingo.py
@@ -26,9 +26,18 @@ def symbols(request):
     return request.param
 
 
+formats = ["csv", "json"]
+format_ids = list(map(str, formats))
+
+
+@pytest.fixture(params=formats, ids=format_ids)
+def formats(request):
+    return request.param
+
+
 @pytest.mark.skipif(TEST_API_KEY is None, reason="TIINGO_API_KEY not set")
-def test_tiingo_quote(symbols):
-    df = TiingoQuoteReader(symbols=symbols).read()
+def test_tiingo_quote(symbols, formats):
+    df = TiingoQuoteReader(symbols=symbols, response_format=formats).read()
     assert isinstance(df, pd.DataFrame)
     if isinstance(symbols, str):
         symbols = [symbols]
@@ -36,8 +45,8 @@ def test_tiingo_quote(symbols):
 
 
 @pytest.mark.skipif(TEST_API_KEY is None, reason="TIINGO_API_KEY not set")
-def test_tiingo_historical(symbols):
-    df = TiingoDailyReader(symbols=symbols).read()
+def test_tiingo_historical(symbols, formats):
+    df = TiingoDailyReader(symbols=symbols, response_format=formats).read()
     assert isinstance(df, pd.DataFrame)
     if isinstance(symbols, str):
         symbols = [symbols]
@@ -45,8 +54,8 @@ def test_tiingo_historical(symbols):
 
 
 @pytest.mark.skipif(TEST_API_KEY is None, reason="TIINGO_API_KEY not set")
-def test_tiingo_iex_historical(symbols):
-    df = TiingoIEXHistoricalReader(symbols=symbols).read()
+def test_tiingo_iex_historical(symbols, formats):
+    df = TiingoIEXHistoricalReader(symbols=symbols, response_format=formats).read()
     df.head()
     assert isinstance(df, pd.DataFrame)
     if isinstance(symbols, str):

--- a/pandas_datareader/tiingo.py
+++ b/pandas_datareader/tiingo.py
@@ -50,12 +50,13 @@ class TiingoIEXHistoricalReader(_BaseReader):
             requests.sessions.Session instance to be used
         freq : {str, None}
             Re-sample frequency. Format is #min/hour; e.g. "15min" or "4hour".
-            If no value is provided, defaults to 5min. The minimum value is\
-                 "1min".
+            If no value is provided, defaults to 5min. The minimum value is "1min".
             Units in minutes (min) and hours (hour) are accepted.
         response_format : str, default 'json'
-            Format of response data returned by the underlying Tiingo REST API.
-            Acceptable values: 'json', 'csv'.
+            Specifies format of response data returned by the underlying
+            Tiingo REST API. Acceptable values are 'json' and 'csv'.
+            Use of 'csv' results in smaller message payload, less bandwidth,
+            and may delay the time when client hits API's bandwidth limit.
         api_key : str, optional
             Tiingo API key . If not provided the environmental variable
             TIINGO_API_KEY is read. The API key is *required*.
@@ -90,9 +91,9 @@ class TiingoIEXHistoricalReader(_BaseReader):
                 "environmental variable TIINGO_API_KEY."
             )
         self.api_key = api_key
-        self.response_format = (
-            response_format if response_format in ["json", "csv"] else "json"
-        )
+        if response_format not in ["json", "csv"]:
+            raise ValueError("Acceptable values are 'json' and 'csv'")
+        self.response_format = response_format
         self._concat_axis = 0
 
     @property
@@ -172,8 +173,10 @@ class TiingoDailyReader(_BaseReader):
     freq : {str, None}
         Not used.
     response_format : str, default 'json'
-        Format of response data returned by the underlying Tiingo REST API.
-        Acceptable values: 'json', 'csv'.
+        Specifies format of response data returned by the underlying
+        Tiingo REST API. Acceptable values are 'json' and 'csv'.
+        Use of 'csv' results in smaller message payload, less bandwidth,
+        and may delay the time when client hits API's bandwidth limit.
     api_key : str, optional
         Tiingo API key . If not provided the environmental variable
         TIINGO_API_KEY is read. The API key is *required*.
@@ -207,9 +210,9 @@ class TiingoDailyReader(_BaseReader):
                 "environmental variable TIINGO_API_KEY."
             )
         self.api_key = api_key
-        self.response_format = (
-            response_format if response_format in ["json", "csv"] else "json"
-        )
+        if response_format not in ["json", "csv"]:
+            raise ValueError("Acceptable values are 'json' and 'csv'")
+        self.response_format = response_format
         self._concat_axis = 0
 
     @property
@@ -303,7 +306,16 @@ class TiingoMetaDataReader(TiingoDailyReader):
         api_key=None,
     ):
         super(TiingoMetaDataReader, self).__init__(
-            symbols, start, end, retry_count, pause, timeout, session, freq, api_key
+            symbols,
+            start,
+            end,
+            retry_count,
+            pause,
+            timeout,
+            session,
+            freq,
+            response_format="json",
+            api_key=api_key,
         )
         self._concat_axis = 1
 
@@ -344,8 +356,10 @@ class TiingoQuoteReader(TiingoDailyReader):
     freq : {str, None}
         Not used.
     response_format : str, default 'json'
-        Format of response data returned by the underlying Tiingo REST API.
-        Acceptable values: 'json', 'csv'.
+        Specifies format of response data returned by the underlying
+        Tiingo REST API. Acceptable values are 'json' and 'csv'.
+        Use of 'csv' results in smaller message payload, less bandwidth,
+        and may delay the time when client hits API's bandwidth limit.
     api_key : str, optional
         Tiingo API key . If not provided the environmental variable
         TIINGO_API_KEY is read. The API key is *required*.

--- a/pandas_datareader/tiingo.py
+++ b/pandas_datareader/tiingo.py
@@ -6,6 +6,7 @@ from pandas_datareader.base import _BaseReader
 
 TIINGO_API_URL_BASE = "https://api.tiingo.com"
 
+
 def get_tiingo_symbols():
     """
     Get the set of stock symbols supported by Tiingo
@@ -48,8 +49,9 @@ class TiingoIEXHistoricalReader(_BaseReader):
         session : Session, default None
             requests.sessions.Session instance to be used
         freq : {str, None}
-            Re-sample frequency. Format is # + (min/hour); e.g. "15min" or "4hour".
-            If no value is provided, defaults to 5min. The minimum value is "1min".
+            Re-sample frequency. Format is #min/hour; e.g. "15min" or "4hour".
+            If no value is provided, defaults to 5min. The minimum value is\
+                 "1min".
             Units in minutes (min) and hours (hour) are accepted.
         response_format : str, default 'json'
             Format of response data returned by the underlying Tiingo REST API.
@@ -69,7 +71,7 @@ class TiingoIEXHistoricalReader(_BaseReader):
         timeout=30,
         session=None,
         freq=None,
-        response_format='json',
+        response_format="json",
         api_key=None,
     ):
         super().__init__(
@@ -88,13 +90,15 @@ class TiingoIEXHistoricalReader(_BaseReader):
                 "environmental variable TIINGO_API_KEY."
             )
         self.api_key = api_key
-        self.response_format = response_format if response_format in ['json', 'csv'] else 'json'
+        self.response_format = (
+            response_format if response_format in ["json", "csv"] else "json"
+        )
         self._concat_axis = 0
 
     @property
     def url(self):
         """API URL"""
-        _url = TIINGO_API_URL_BASE+"/iex/{ticker}/prices"
+        _url = TIINGO_API_URL_BASE + "/iex/{ticker}/prices"
         return _url.format(ticker=self._symbol)
 
     @property
@@ -112,20 +116,22 @@ class TiingoIEXHistoricalReader(_BaseReader):
 
     def _read_one_data(self, url, params):
         """ read one data from specified URL """
-        content_type = "application/json" if self.response_format == "json" else "text/csv"
+        content_type = (
+            "application/json" if self.response_format == "json" else "text/csv"
+        )
         headers = {
             "Content-Type": content_type,
             "Authorization": "Token " + self.api_key,
         }
         out = None
-        if self.response_format == 'json':
-            out = self._get_response(url, params=params, headers=headers).json() 
-        elif self.response_format == 'csv':
+        if self.response_format == "json":
+            out = self._get_response(url, params=params, headers=headers).json()
+        elif self.response_format == "csv":
             out = self._read_url_as_StringIO(url, params=params, headers=headers)
         return self._read_lines(out)
 
     def _read_lines(self, out):
-        df = pd.DataFrame(out) if self.response_format == 'json' else pd.read_csv(out)
+        df = pd.DataFrame(out) if self.response_format == "json" else pd.read_csv(out)
         df["symbol"] = self._symbol
         df["date"] = pd.to_datetime(df["date"])
         df = df.set_index(["symbol", "date"])
@@ -183,7 +189,7 @@ class TiingoDailyReader(_BaseReader):
         timeout=30,
         session=None,
         freq=None,
-        response_format='json',
+        response_format="json",
         api_key=None,
     ):
         super(TiingoDailyReader, self).__init__(
@@ -201,13 +207,15 @@ class TiingoDailyReader(_BaseReader):
                 "environmental variable TIINGO_API_KEY."
             )
         self.api_key = api_key
-        self.response_format = response_format if response_format in ['json', 'csv'] else 'json'
+        self.response_format = (
+            response_format if response_format in ["json", "csv"] else "json"
+        )
         self._concat_axis = 0
 
     @property
     def url(self):
         """API URL"""
-        _url = TIINGO_API_URL_BASE+"/tiingo/daily/{ticker}/prices"
+        _url = TIINGO_API_URL_BASE + "/tiingo/daily/{ticker}/prices"
         return _url.format(ticker=self._symbol)
 
     @property
@@ -216,7 +224,7 @@ class TiingoDailyReader(_BaseReader):
         return {
             "startDate": self.start.strftime("%Y-%m-%d"),
             "endDate": self.end.strftime("%Y-%m-%d"),
-            "format": self.response_format
+            "format": self.response_format,
         }
 
     def _get_crumb(self, *args):
@@ -224,20 +232,22 @@ class TiingoDailyReader(_BaseReader):
 
     def _read_one_data(self, url, params):
         """ read one data from specified URL """
-        content_type = "application/json" if self.response_format == "json" else "text/csv"
+        content_type = (
+            "application/json" if self.response_format == "json" else "text/csv"
+        )
         headers = {
             "Content-Type": content_type,
             "Authorization": "Token " + self.api_key,
         }
         out = None
-        if self.response_format == 'json':
-            out = self._get_response(url, params=params, headers=headers).json() 
-        elif self.response_format == 'csv':
+        if self.response_format == "json":
+            out = self._get_response(url, params=params, headers=headers).json()
+        elif self.response_format == "csv":
             out = self._read_url_as_StringIO(url, params=params, headers=headers)
         return self._read_lines(out)
 
     def _read_lines(self, out):
-        df = pd.DataFrame(out) if self.response_format == 'json' else pd.read_csv(out)
+        df = pd.DataFrame(out) if self.response_format == "json" else pd.read_csv(out)
         df["symbol"] = self._symbol
         df["date"] = pd.to_datetime(df["date"])
         df = df.set_index(["symbol", "date"])
@@ -293,15 +303,14 @@ class TiingoMetaDataReader(TiingoDailyReader):
         api_key=None,
     ):
         super(TiingoMetaDataReader, self).__init__(
-            symbols, start, end, retry_count, pause, timeout, session, freq,
-            api_key
+            symbols, start, end, retry_count, pause, timeout, session, freq, api_key
         )
         self._concat_axis = 1
 
     @property
     def url(self):
         """API URL"""
-        _url = TIINGO_API_URL_BASE+"/tiingo/daily/{ticker}"
+        _url = TIINGO_API_URL_BASE + "/tiingo/daily/{ticker}"
         return _url.format(ticker=self._symbol)
 
     @property
@@ -346,6 +355,7 @@ class TiingoQuoteReader(TiingoDailyReader):
     This is a special case of the daily reader which automatically selected
     the latest data available for each symbol.
     """
+
     def __init__(
         self,
         symbols,
@@ -356,17 +366,23 @@ class TiingoQuoteReader(TiingoDailyReader):
         timeout=30,
         session=None,
         freq=None,
-        response_format='json',
-        api_key=None
+        response_format="json",
+        api_key=None,
     ):
         super(TiingoQuoteReader, self).__init__(
-            symbols, start, end, retry_count, pause, timeout, session, freq,
-            response_format, api_key
+            symbols,
+            start,
+            end,
+            retry_count,
+            pause,
+            timeout,
+            session,
+            freq,
+            response_format,
+            api_key,
         )
 
     @property
     def params(self):
         """Parameters to use in API calls"""
-        return {
-            "format": self.response_format
-        }
+        return {"format": self.response_format}


### PR DESCRIPTION
- [y] closes #821
- [y] tests added / passed *
- [y] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [y] passes `black --check pandas_datareader`
- [y] added entry to docs/source/whatsnew/v.0.9.1.txt

* Tests added as 'formats' fixture parametrisations ('json', 'csv') in test_tiingo.py