### PR TITLE
grammar fix in docs (up-to-date instead of up to date)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ pandas-datareader
 
 .. include:: _version.txt
 
-Up to date remote data access for pandas, works for multiple versions of pandas.
+Up-to-date remote data access for pandas, works for multiple versions of pandas.
 
 
 Quick Start

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ pandas-datareader
 
 .. include:: _version.txt
 
-Up-to-date remote data access for pandas, works for multiple versions of pandas.
+Up-to-date remote data access for pandas. Works for multiple versions of pandas.
 
 
 Quick Start


### PR DESCRIPTION
needs hyphens. 

http://www.thewriter.com/what-we-think/style-guide/to-hyphenate-or-not-to-hyphenate/#:~:text=When%20it%20comes%20after%20the,up%2Dto%2Ddate%20document.

only touched one line of the docs
