### PR TITLE
docs: fix simple typo, recevied -> received

### DIFF
--- a/pandas_datareader/moex.py
+++ b/pandas_datareader/moex.py
@@ -185,7 +185,7 @@ class MoexReader(_DailyBaseReader):
                             break
                     else:
                         out_list += strings_out[1:]  # remove a CSV head line
-                        if len(strings_out) < 100:  # all data recevied - break
+                        if len(strings_out) < 100:  # all data received - break
                             break
 
                 if len(out_list) > 0:


### PR DESCRIPTION
There is a small typo in pandas_datareader/moex.py.

Should read `received` rather than `recevied`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md