### PR TITLE
Fix the unstacking when data contains duplicated rows with the same index

### DIFF
--- a/docs/source/whatsnew/v0.9.1.txt
+++ b/docs/source/whatsnew/v0.9.1.txt
@@ -20,13 +20,15 @@ Enhancements
   from every trading board (ver. 0.9.0 behaviour)
 - Docs for MOEX reedited
 
-.. _whatsnew_080.bug_fixes:
+.. _whatsnew_091.bug_fixes:
 
 Bug Fixes
 ~~~~~~~~~
 
 - Fixed broken links on the github ussies on "What’s New" docs pages
+- Deduplicate rows with the same index (:issue:`610`) (:issue:`738`)
 
 Contributors
 ~~~~~~~~~~~~
 - Dmitry Alekseev
+- Chang Lan

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -265,7 +265,10 @@ class _DailyBaseReader(_BaseReader):
         for sym_group in _in_chunks(symbols, self.chunksize):
             for sym in sym_group:
                 try:
-                    stocks[sym] = self._read_one_data(self.url, self._get_params(sym))
+                    df = self._read_one_data(self.url, self._get_params(sym))
+                    # Keep the last item if there are duplicated rows with the same index.
+                    df = df[~df.index.duplicated(keep='last')]
+                    stocks[sym] = df
                     passed.append(sym)
                 except (IOError, KeyError):
                     msg = "Failed to read symbol: {0!r}, replacing with NaN."

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -139,7 +139,7 @@ class _BaseReader(object):
         return response.content
 
     def _get_response(self, url, params=None, headers=None):
-        """ send raw HTTP request to get requests.Response from the specified url
+        """send raw HTTP request to get requests.Response from the specified url
         Parameters
         ----------
         url : str
@@ -267,7 +267,7 @@ class _DailyBaseReader(_BaseReader):
                 try:
                     df = self._read_one_data(self.url, self._get_params(sym))
                     # Keep the last item if there are duplicated rows with the same index.
-                    df = df[~df.index.duplicated(keep='last')]
+                    df = df[~df.index.duplicated(keep="last")]
                     stocks[sym] = df
                     passed.append(sym)
                 except (IOError, KeyError):


### PR DESCRIPTION
- [x] closes #738
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check pandas_datareader`
- [x] added entry to docs/source/whatsnew/v0.9.1.txt
