### PR TITLE
Remove chunksize from AV, fix tests

### DIFF
--- a/docs/source/whatsnew/v0.9.1.txt
+++ b/docs/source/whatsnew/v0.9.1.txt
@@ -26,7 +26,10 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixed broken links on the github ussies on "What’s New" docs pages
+- Fixed tests on av.time_series.py so they can run with a free API key
+- Cleanup unused chunksize in av.time_series.py
 
 Contributors
 ~~~~~~~~~~~~
 - Dmitry Alekseev
+- Jun Wei Fu

--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -51,7 +51,6 @@ class AVTimeSeriesReader(AlphaVantage):
         retry_count=3,
         pause=0.1,
         session=None,
-        chunksize=25,
         api_key=None,
     ):
         self._func = function

--- a/pandas_datareader/av/time_series.py
+++ b/pandas_datareader/av/time_series.py
@@ -83,7 +83,7 @@ class AVTimeSeriesReader(AlphaVantage):
 
     @property
     def output_size(self):
-        """ Used to limit the size of the Alpha Vantage query when
+        """Used to limit the size of the Alpha Vantage query when
         possible.
         """
         delta = dt.datetime.now() - self.start

--- a/pandas_datareader/tests/av/test_av_time_series.py
+++ b/pandas_datareader/tests/av/test_av_time_series.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import time
 
 import pandas as pd
 import pytest
@@ -53,6 +54,8 @@ class TestAVTimeSeries(object):
                 pause=20.5,
             )
 
+        time.sleep(20.5)
+
     def test_av_daily(self):
         df = web.DataReader(
             "AAPL",
@@ -73,6 +76,8 @@ class TestAVTimeSeries(object):
         expected2 = df.loc["2017-05-24"]
         assert expected2["close"] == 153.34
         assert expected2["high"] == 154.17
+
+        time.sleep(20.5)
 
     def test_av_daily_adjusted(self):
         df = web.DataReader(
@@ -112,6 +117,8 @@ class TestAVTimeSeries(object):
         assert expected2["dividend amount"] == 0.00
         assert expected2["split coefficient"] == 1.0
 
+        time.sleep(20.5)
+
     @staticmethod
     def _helper_df_weekly_monthly(df, adj=False):
 
@@ -139,6 +146,8 @@ class TestAVTimeSeries(object):
         assert df.columns.equals(self.col_index)
         self._helper_df_weekly_monthly(df, adj=False)
 
+        time.sleep(20.5)
+
     def test_av_weekly_adjusted(self):
         df = web.DataReader(
             "AAPL",
@@ -154,6 +163,8 @@ class TestAVTimeSeries(object):
         assert df.iloc[-1].name == "2017-05-19"
         assert df.columns.equals(self.col_index_adj)
         self._helper_df_weekly_monthly(df, adj=True)
+
+        time.sleep(20.5)
 
     def test_av_monthly(self):
         df = web.DataReader(
@@ -171,6 +182,8 @@ class TestAVTimeSeries(object):
         assert df.columns.equals(self.col_index)
         self._helper_df_weekly_monthly(df, adj=False)
 
+        time.sleep(20.5)
+
     def test_av_monthly_adjusted(self):
         df = web.DataReader(
             "AAPL",
@@ -187,6 +200,8 @@ class TestAVTimeSeries(object):
         assert df.iloc[-1].name == "2017-04-28"
         self._helper_df_weekly_monthly(df, adj=True)
 
+        time.sleep(20.5)
+
     def test_av_intraday(self):
         # Not much available to test, but ensure close in length
         df = web.DataReader("AAPL", "av-intraday", retry_count=6, pause=20.5)
@@ -194,6 +209,8 @@ class TestAVTimeSeries(object):
         assert len(df) >= 1
         assert "open" in df.columns
         assert "close" in df.columns
+
+        time.sleep(20.5)
 
     def test_av_forex_daily(self):
         df = web.DataReader(
@@ -208,3 +225,5 @@ class TestAVTimeSeries(object):
         assert len(df) == 598
         assert df.loc["2015-02-09"]["close"] == 118.6390
         assert df.loc["2017-05-24"]["high"] == 112.1290
+
+        time.sleep(20.5)


### PR DESCRIPTION
- [x] tests added / passed: introduced sleeps between each test to prevent hitting the API limits.
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check pandas_datareader`: pass for my impacted files
- [x] added entry to docs/source/whatsnew/vLATEST.txt

This is my first PR on this amazing project, sorry if I got any of the process wrong!