### PR TITLE
Update famafrench.py

### DIFF
--- a/pandas_datareader/famafrench.py
+++ b/pandas_datareader/famafrench.py
@@ -58,7 +58,8 @@ class FamaFrenchReader(_BaseReader):
             tmpf.write(raw)
 
             with ZipFile(tmpf, "r") as zf:
-                data = zf.open(zf.namelist()[0]).read().decode()
+                data = zf.open(zf.namelist()[0]).read().decode('utf-8','ignore')
+
 
         return data
 


### PR DESCRIPTION
This change allows the `pandas_datareader` library to read Windows text files with smart quotes and apostrophes and still convert all other characters to UTF-8, where needed.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
