### PR TITLE
Update moex.py

### DIFF
--- a/pandas_datareader/moex.py
+++ b/pandas_datareader/moex.py
@@ -190,7 +190,10 @@ class MoexReader(_DailyBaseReader):
 
                 if len(out_list) > 0:
                     str_io = StringIO("\r\n".join(out_list))
-                    dfs.append(self._read_lines(str_io))  # add a new DataFrame
+                    try:
+                        dfs.append(self._read_lines(str_io))  # add a new DataFrame
+                    except ValueError: # if no suitable dataframe read (boards without data)
+                        pass
         finally:
             self.close()
 


### PR DESCRIPTION
read fails if no TRADEDATE in received data, for example read('SiM1') reads fortsiqs board that doesn't have any data

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
