### PR TITLE
Fix usage of pandas.io.common.get_filepath_or_buffer

### DIFF
--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -40,9 +40,10 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None, compression=None):
     if isinstance(filepath_or_buffer, dict):
         return filepath_or_buffer, encoding, compression
 
-    return com.get_filepath_or_buffer(
+    tmp = com._get_filepath_or_buffer(
         filepath_or_buffer, encoding=encoding, compression=None
     )
+    return tmp.filepath_or_buffer, tmp.encoding, tmp.compression
 
 
 string_types = (str,)


### PR DESCRIPTION
It seems like pandas (I am using v1.2.1) renamed `pandas.io.common.get_filepath_or_buffer` to `pandas.io.common._get_filepath_or_buffer` and changed its signature.
This makes, e.g., code like this crash:
```python
import pandas_datareader as pdr
pdr.data.DataReader('hlth_hlye', 'eurostat')
```

This PR makes `pandas_datareader.compat.get_filepath_or_buffer` use the new interface.