### PR TITLE
Update daily.py

### DIFF
--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -63,7 +63,7 @@ class YahooDailyReader(_DailyBaseReader):
         adjust_price=False,
         ret_index=False,
         chunksize=1,
-        interval="d",
+        interval="1d",
         get_actions=False,
         adjust_dividends=True,
     ):

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -150,7 +150,7 @@ class YahooDailyReader(_DailyBaseReader):
         del params["symbol"]
         url = url.format(symbol)
 
-        resp = self._get_response(url, params=params)
+        resp = self._get_response(url, params=params, headers=self.headers)
         ptrn = r"root\.App\.main = (.*?);\n}\(this\)\);"
         try:
             j = json.loads(re.search(ptrn, resp.text, re.DOTALL).group(1))


### PR DESCRIPTION
**Why:**
Yahoo Finance must have changed their API in the last few weeks causing errors or no returned data.

**What:**
I've changed the default interval to `"1d"` instead of `"d"` and added the missing headers in the `_get_response` call in the `_read_one_data` method of the `YahooDailyReader` class. With the proposed change, I was able to get the data from Yahoo's Finance API. Note that other intervals are effected too, but the DataReader class seems to use `"d"` only.

