### PR TITLE
Drop row with duplicated index

### DIFF
--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -167,6 +167,8 @@ class YahooDailyReader(_DailyBaseReader):
 
         prices = prices.set_index("Date")
         prices = prices.sort_index().dropna(how="all")
+        prices = prices[~prices.index.duplicated()]
+
 
         if self.ret_index:
             prices["Ret_Index"] = _calc_return_index(prices["Adj Close"])

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -169,7 +169,6 @@ class YahooDailyReader(_DailyBaseReader):
         prices = prices.sort_index().dropna(how="all")
         prices = prices[~prices.index.duplicated()]
 
-
         if self.ret_index:
             prices["Ret_Index"] = _calc_return_index(prices["Adj Close"])
         if self.adjust_price:


### PR DESCRIPTION
There are cases in yahoo data where there are duplicated rows, this simple fix will remove the second duplicated row if it exists.  A stack overflow thread that contains people facing this error is https://stackoverflow.com/questions/57885790/valueerror-index-contains-duplicate-entries-cannot-reshape-pandas-datareader

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
