### PR TITLE
Fix doc of StooqDailyReader freq argument

### DIFF
--- a/pandas_datareader/stooq.py
+++ b/pandas_datareader/stooq.py
@@ -27,7 +27,6 @@ class StooqDailyReader(_DailyBaseReader):
         Number of symbols to download consecutively before initiating pause.
     session : Session, default None
         requests.sessions.Session instance to be used
-    freq: string, d, w, m ,q, y for daily, weekly, monthly, quarterly, yearly
 
     Notes
     -----


### PR DESCRIPTION
_DailyBaseReader does not have the `freq` parameter.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
