### PR TITLE
Updates to fix linting task in ci/cd pipeline

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+ignore = B904
+exclude =
+    docs/,
+    build/,
+    dist/,
+    .tox/,
+    .venv/,
+    .pytest_cache/,
+    .ipynb_checkpoints/,

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/build
 env/
 .pytest_cache/
 .vscode/
+.venv/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,15 @@
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#passing-parameters
 schedules:
-- cron: "27 3 * * 0"
-  # 3:27am UTC every Sunday
-  displayName: Weekly build
-  branches:
-    include:
-    - main
-  always: true
+  - cron: "27 3 * * 0"
+    # 3:27am UTC every Sunday
+    displayName: Weekly build
+    branches:
+      include:
+        - main
+    always: true
 
 trigger:
-- main
+  - main
 
 variables:
   PYTHONHASHSEED: 12345678
@@ -18,13 +18,12 @@ variables:
   RANDOMGEN_CYTHON_COVERAGE: true
 
 jobs:
-    
-- template: ci/azure/azure_template_posix.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-20.04
+  - template: ci/azure/azure_template_posix.yml
+    parameters:
+      name: Linux
+      vmImage: ubuntu-20.04
 
-- template: ci/azure/azure_template_windows.yml
-  parameters:
-    name: Windows
-    vmImage: windows-2019
+  - template: ci/azure/azure_template_windows.yml
+    parameters:
+      name: Windows
+      vmImage: windows-2019

--- a/ci/azure/azure_template_posix.yml
+++ b/ci/azure/azure_template_posix.yml
@@ -16,20 +16,20 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      ${{ if eq(parameters.name, 'Linux') }}:
-        python36_legacy:
-          python.version: '3.6'
-          PANDAS: 1.0.5
-        python37_legacy:
-          python.version: '3.7'
-          PANDAS: 1.1.5
-        python38_recent:
-          python.version: '3.8'
-          PANDAS: 1.2.5
-        python39_latest:
-          python.version: '3.9'
-
-    # maxParallel: 10
+      python36_legacy:
+        python.version: '3.6'
+        PANDAS: 1.0.5
+      python37_legacy:
+        python.version: '3.7'
+        PANDAS: 1.1.5
+      python38_recent:
+        python.version: '3.8'
+        PANDAS: 1.2.5
+      python39_recent:
+        python.version: '3.9'
+        PANDAS: 1.3.5
+      python310_latest:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0

--- a/ci/azure/azure_template_windows.yml
+++ b/ci/azure/azure_template_windows.yml
@@ -16,20 +16,20 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      ${{ if eq(parameters.name, 'Linux') }}:
-        python37_legacy:
-          python.version: '3.7'
-          PANDAS: 1.0.5
-        python38_legacy:
-          python.version: '3.8'
-          PANDAS: 1.1.5
-        python38_recent:
-          python.version: '3.8'
-          PANDAS: 1.2.5
-        python39_latest:
-          python.version: '3.9'
-
-    # maxParallel: 10
+      python37_legacy:
+        python.version: '3.7'
+        PANDAS: 1.0.5
+      python38_legacy:
+        python.version: '3.8'
+        PANDAS: 1.1.5
+      python38_recent:
+        python.version: '3.8'
+        PANDAS: 1.2.5
+      python39_recent:
+        python.version: '3.9'
+        PANDAS: 1.3.5
+      python310_latest:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0

--- a/pandas_datareader/_utils.py
+++ b/pandas_datareader/_utils.py
@@ -47,7 +47,7 @@ def _sanitize_dates(start, end):
         start = to_datetime(start)
         end = to_datetime(end)
     except (TypeError, ValueError):
-        raise ValueError("Invalid date format.")
+        raise ValueError("Invalid date format.") from None
     if start > end:
         raise ValueError("start must be an earlier date than end")
     return start, end

--- a/pandas_datareader/av/__init__.py
+++ b/pandas_datareader/av/__init__.py
@@ -76,12 +76,12 @@ class AlphaVantage(_BaseReader):
                     "The requested symbol {} could not be "
                     "retrieved. Check valid ticker"
                     ".".format(self.symbols)
-                )
+                ) from None
             else:
                 raise RemoteDataError(
                     " Their was an issue from the data vendor "
                     "side, here is their response: {}".format(out)
-                )
+                ) from None
         df = df[sorted(df.columns)]
         df.columns = [id[3:] for id in df.columns]
         return df

--- a/pandas_datareader/av/forex.py
+++ b/pandas_datareader/av/forex.py
@@ -57,7 +57,7 @@ class AVForexReader(AlphaVantage):
                 "Please input a currency pair "
                 "formatted 'FROM/TO' or a list of "
                 "currency symbols"
-            )
+            ) from None
 
     @property
     def function(self):
@@ -90,7 +90,7 @@ class AVForexReader(AlphaVantage):
         try:
             df = pd.DataFrame.from_dict(out[self.data_key], orient="index")
         except KeyError:
-            raise RemoteDataError()
+            raise RemoteDataError() from None
         df.sort_index(ascending=True, inplace=True)
         df.index = [id[3:] for id in df.index]
         return df

--- a/pandas_datareader/base.py
+++ b/pandas_datareader/base.py
@@ -290,7 +290,7 @@ class _DailyBaseReader(_BaseReader):
         except AttributeError:
             # cannot construct a panel with just 1D nans indicating no data
             msg = "No data fetched using {0!r}"
-            raise RemoteDataError(msg.format(self.__class__.__name__))
+            raise RemoteDataError(msg.format(self.__class__.__name__)) from None
 
 
 def _in_chunks(seq, size):

--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -1,7 +1,7 @@
-from packaging import version
 from io import StringIO
 from urllib.error import HTTPError
 
+from packaging import version
 import pandas as pd
 from pandas.api.types import is_list_like, is_number
 from pandas.io import common as com

--- a/pandas_datareader/famafrench.py
+++ b/pandas_datareader/famafrench.py
@@ -146,11 +146,11 @@ class FamaFrenchReader(_BaseReader):
         """
         try:
             from lxml.html import document_fromstring
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
                 "Please install lxml if you want to use the "
                 "get_datasets_famafrench function"
-            )
+            ) from err
 
         response = self.session.get(_URL + "data_library.html")
         root = document_fromstring(response.content)

--- a/pandas_datareader/fred.py
+++ b/pandas_datareader/fred.py
@@ -55,7 +55,7 @@ class FredReader(_BaseReader):
                     raise IOError(
                         "Failed to get the data. Check that "
                         "{0!r} is a valid FRED series.".format(name)
-                    )
+                    ) from None
                 raise
 
         df = concat(

--- a/pandas_datareader/iex/__init__.py
+++ b/pandas_datareader/iex/__init__.py
@@ -72,7 +72,7 @@ class IEX(_BaseReader):
         try:
             content = json.loads(out.text)
         except Exception:
-            raise TypeError("Failed to interpret response as JSON.")
+            raise TypeError("Failed to interpret response as JSON.") from None
 
         for key, string in content.items():
             e = "IEX Output error encountered: {}".format(string)

--- a/pandas_datareader/io/jsdmx.py
+++ b/pandas_datareader/io/jsdmx.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 import itertools
 import re
-import sys
 
 import numpy as np
 import pandas as pd
@@ -32,8 +31,6 @@ def read_jsdmx(path_or_buf):
     try:
         import simplejson as json
     except ImportError:
-        if sys.version_info[:2] < (2, 7):
-            raise ImportError("simplejson is required in python 2.6")
         import json
 
     if isinstance(jdata, dict):

--- a/pandas_datareader/io/sdmx.py
+++ b/pandas_datareader/io/sdmx.py
@@ -57,7 +57,7 @@ def read_sdmx(path_or_buf, dtype="float64", dsd=None):
         # get zipped path
         result = list(root.iter(_COMMON + "Text"))[1].text
         if not result.startswith("http"):
-            raise ValueError(result)
+            raise ValueError(result) from None
 
         for _ in range(60):
             # wait zipped data is prepared
@@ -72,7 +72,7 @@ def read_sdmx(path_or_buf, dtype="float64", dsd=None):
             "Unable to download zipped data within 60 secs, "
             "please download it manually from: {0}"
         )
-        raise ValueError(msg.format(result))
+        raise ValueError(msg.format(result)) from None
 
     idx_name = structure.get("dimensionAtObservation")
     dataset = _get_child(root, _DATASET)

--- a/pandas_datareader/nasdaq_trader.py
+++ b/pandas_datareader/nasdaq_trader.py
@@ -41,7 +41,9 @@ def _download_nasdaq_symbols(timeout):
         ftp_session = FTP(_NASDAQ_FTP_SERVER, timeout=timeout)
         ftp_session.login()
     except all_errors as err:
-        raise RemoteDataError("Error connecting to %r: %s" % (_NASDAQ_FTP_SERVER, err))
+        raise RemoteDataError(
+            "Error connecting to %r: %s" % (_NASDAQ_FTP_SERVER, err)
+        ) from err
 
     lines = []
     try:
@@ -49,7 +51,7 @@ def _download_nasdaq_symbols(timeout):
     except all_errors as err:
         raise RemoteDataError(
             "Error downloading from %r: %s" % (_NASDAQ_FTP_SERVER, err)
-        )
+        ) from err
     finally:
         ftp_session.close()
 

--- a/pandas_datareader/tests/io/test_jsdmx.py
+++ b/pandas_datareader/tests/io/test_jsdmx.py
@@ -170,7 +170,7 @@ def test_quartervalue(dirpath):
             "2011-10-01",
         ],
         dtype="datetime64[ns]",
-        name=u"Period",
+        name="Period",
         freq=None,
     )
     tm.assert_index_equal(result.index, expected)

--- a/pandas_datareader/tests/yahoo/test_options.py
+++ b/pandas_datareader/tests/yahoo/test_options.py
@@ -100,7 +100,7 @@ class TestYahooOptions(object):
             ]
         )
         tm.assert_index_equal(df.columns, exp_columns)
-        assert df.index.names == [u"Strike", u"Expiry", u"Type", u"Symbol"]
+        assert df.index.names == ["Strike", "Expiry", "Type", "Symbol"]
 
         dtypes = [
             np.dtype(x)

--- a/pandas_datareader/wb.py
+++ b/pandas_datareader/wb.py
@@ -651,10 +651,10 @@ class WorldBankReader(_BaseReader):
                 df.columns = ["country", "iso_code", "year", indicator]
                 data.append(df)
 
-            except ValueError as e:
-                msg = str(e) + " Indicator: " + indicator
+            except ValueError as err:
+                msg = str(err) + " Indicator: " + indicator
                 if self.errors == "raise":
-                    raise ValueError(msg)
+                    raise ValueError(msg) from err
                 elif self.errors == "warn":
                     warnings.warn(msg)
 

--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -153,7 +153,7 @@ class YahooDailyReader(_DailyBaseReader):
             data = j["context"]["dispatcher"]["stores"]["HistoricalPriceStore"]
         except KeyError:
             msg = "No data fetched for symbol {} using {}"
-            raise RemoteDataError(msg.format(symbol, self.__class__.__name__))
+            raise RemoteDataError(msg.format(symbol, self.__class__.__name__)) from None
 
         # price data
         prices = DataFrame(data["prices"])

--- a/pandas_datareader/yahoo/options.py
+++ b/pandas_datareader/yahoo/options.py
@@ -143,8 +143,10 @@ class Options(_OptionBaseReader):
         try:
             calls = result["options"]["calls"]
             puts = result["options"]["puts"]
-        except IndexError:
-            raise RemoteDataError("Option json not available " "for url: %s" % url)
+        except IndexError as err:
+            raise RemoteDataError(
+                "Option json not available " "for url: %s" % url
+            ) from err
 
         self.underlying_price = (
             result["quote"]["regularMarketPrice"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-black==21.5b1; python_version > '3.5'
-flake8-bugbear; python_version > '3.5'
+black
+flake8-bugbear
 coverage
 codecov
 coveralls
@@ -8,3 +8,5 @@ pytest
 pytest-xdist
 pytest-cov
 wrapt
+tox
+isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black
+black==22.3.0
 flake8-bugbear
 coverage
 codecov

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,16 @@ import versioneer
 with open("./requirements.txt") as f:
     install_requires = f.read().splitlines()
 
+with open("./requirements-dev.txt") as f:
+    dev_requires = f.read().splitlines()
+
 setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,
+    extras_require={
+        "dev": dev_requires
+    },
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     zip_safe=False,
     python_requires=">=3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,21 @@
 [tox]
-envlist=py{27,35,36,37}
+envlist=py{36,37,38,39,310}
 
 [testenv]
 commands=
-    pytest
+    pytest pandas_datareader/tests
 deps=
     pytest>=4.0.2
     pytest-cov
     wrapt
+
+[testenv:lint]
+commands=
+    black --check pandas_datareader
+    isort --check pandas_datareader
+    flake8 pandas_datareader
+deps=
+    black
+    isort
+    flake8
+    flake8-bugbear


### PR DESCRIPTION
The CI/CD pipeline is failing because the `requirements-dev.txt`  file is missing `isort`. I ran black and isort after making the update and his modified some additional files. The pipeline is still failing due to flake8.

### Changes
- Adds isort to dev dependencies
- Adds dev dependencies to setup.py
- Adds lint session to tox for local testing

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
