### PR TITLE
Decoding stores that was encrypted by Yahoo! Finance recently

### DIFF
--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -4,11 +4,84 @@ import json
 import re
 import time
 
+import hashlib
+from base64 import b64decode
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+
 from pandas import DataFrame, isnull, notnull, to_datetime
 
 from pandas_datareader._utils import RemoteDataError
 from pandas_datareader.base import _DailyBaseReader
 from pandas_datareader.yahoo.headers import DEFAULT_HEADERS
+
+
+def decrypt_cryptojs_aes(data):
+    encrypted_stores = data['context']['dispatcher']['stores']
+    _cs = data["_cs"]
+    _cr = data["_cr"]
+
+    _cr = b"".join(int.to_bytes(i, length=4, byteorder="big", signed=True) for i in json.loads(_cr)["words"])
+    password = hashlib.pbkdf2_hmac("sha1", _cs.encode("utf8"), _cr, 1, dklen=32).hex()
+
+    encrypted_stores = b64decode(encrypted_stores)
+    assert encrypted_stores[0:8] == b"Salted__"
+    salt = encrypted_stores[8:16]
+    encrypted_stores = encrypted_stores[16:]
+
+    def EVPKDF(
+            password,
+            salt,
+            keySize=32,
+            ivSize=16,
+            iterations=1,
+            hashAlgorithm="md5",
+    ) -> tuple:
+        """OpenSSL EVP Key Derivation Function
+        Args:
+            password (Union[str, bytes, bytearray]): Password to generate key from.
+            salt (Union[bytes, bytearray]): Salt to use.
+            keySize (int, optional): Output key length in bytes. Defaults to 32.
+            ivSize (int, optional): Output Initialization Vector (IV) length in bytes. Defaults to 16.
+            iterations (int, optional): Number of iterations to perform. Defaults to 1.
+            hashAlgorithm (str, optional): Hash algorithm to use for the KDF. Defaults to 'md5'.
+        Returns:
+            key, iv: Derived key and Initialization Vector (IV) bytes.
+        Taken from: https://gist.github.com/rafiibrahim8/0cd0f8c46896cafef6486cb1a50a16d3
+        OpenSSL original code: https://github.com/openssl/openssl/blob/master/crypto/evp/evp_key.c#L78
+        """
+
+        assert iterations > 0, "Iterations can not be less than 1."
+
+        if isinstance(password, str):
+            password = password.encode("utf-8")
+
+        final_length = keySize + ivSize
+        key_iv = b""
+        block = None
+
+        while len(key_iv) < final_length:
+            hasher = hashlib.new(hashAlgorithm)
+            if block:
+                hasher.update(block)
+            hasher.update(password)
+            hasher.update(salt)
+            block = hasher.digest()
+            for _ in range(1, iterations):
+                block = hashlib.new(hashAlgorithm, block).digest()
+            key_iv += block
+
+        key, iv = key_iv[:keySize], key_iv[keySize:final_length]
+        return key, iv
+
+    key, iv = EVPKDF(password, salt, keySize=32, ivSize=16, iterations=1, hashAlgorithm="md5")
+
+    cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+    plaintext = cipher.decrypt(encrypted_stores)
+    plaintext = unpad(plaintext, 16, style="pkcs7")
+    decoded_stores = json.loads(plaintext)
+
+    return decoded_stores
 
 
 class YahooDailyReader(_DailyBaseReader):
@@ -56,19 +129,19 @@ class YahooDailyReader(_DailyBaseReader):
     """
 
     def __init__(
-        self,
-        symbols=None,
-        start=None,
-        end=None,
-        retry_count=3,
-        pause=0.1,
-        session=None,
-        adjust_price=False,
-        ret_index=False,
-        chunksize=1,
-        interval="d",
-        get_actions=False,
-        adjust_dividends=True,
+            self,
+            symbols=None,
+            start=None,
+            end=None,
+            retry_count=3,
+            pause=0.1,
+            session=None,
+            adjust_price=False,
+            ret_index=False,
+            chunksize=1,
+            interval="d",
+            get_actions=False,
+            adjust_dividends=True,
     ):
         super().__init__(
             symbols=symbols,
@@ -150,7 +223,13 @@ class YahooDailyReader(_DailyBaseReader):
         ptrn = r"root\.App\.main = (.*?);\n}\(this\)\);"
         try:
             j = json.loads(re.search(ptrn, resp.text, re.DOTALL).group(1))
-            data = j["context"]["dispatcher"]["stores"]["HistoricalPriceStore"]
+
+            if "_cs" in j and "_cr" in j:
+                new_j = decrypt_cryptojs_aes(j)  # returns j["context"]["dispatcher"]["stores"]
+                # from old code
+
+            data = new_j['HistoricalPriceStore']
+
         except KeyError:
             msg = "No data fetched for symbol {} using {}"
             raise RemoteDataError(msg.format(symbol, self.__class__.__name__))


### PR DESCRIPTION
Sorry for any invonvenience, I am new to working on git in such a 
professional manor so expect errors with pull request.

Changes:

In pandas-datareader/yahoo/daily.py/
    
    I have added function decrypt_cryptojs_aes() to decode the
    stores that were previously not allowing any stock data to be 
    accessed from Yahoo! Finance due to their new change.
  
    Additionally just changed _read_one_data() so that it reads the
    decoded stores and passes on stock data correctly.

I have tested this on a limited number of stocks on my personal
project and works good.
I have ran the test_yahoo.py and passed 16, failed 4. However, it 
still is more tests than the current version on GitHub now due to
Yahoo! Finance new change (I dont think any Yahoo! stocks work atm). 
I am unsure of the tests that are failing so some help would be great.
I am sure this can be used just as a temporary fix!

I also don't know how to run the 3rd and 4th bullet points below.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
