### PR TITLE
Fix 'DataFrame' object has no attribute 'append' error in MoexReader

### DIFF
--- a/pandas_datareader/moex.py
+++ b/pandas_datareader/moex.py
@@ -209,10 +209,11 @@ class MoexReader(_DailyBaseReader):
         """Read data from the primary board for each ticker"""
         markets_n_engines, boards = self._get_metadata()
         b = self.read_all_boards()
-        result = pd.DataFrame()
+        parts = []
         for secid in list(set(b["SECID"].tolist())):
             part = b[b["BOARDID"] == boards[secid]]
-            result = result.append(part)
+            parts.append(part)
+        result = pd.concat(parts)
         result = result.drop_duplicates()
         return result
 


### PR DESCRIPTION
Closes pydata/pandas-datareader#966

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
