### PR TITLE
Fix error ImportError: cannot import name 'reduce' from 'pandas_datareader.compat'

### DIFF
--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -1,4 +1,5 @@
 from packaging import version
+from functools import reduce
 from io import StringIO
 from urllib.error import HTTPError
 


### PR DESCRIPTION
Closes #974

- [x] closes #974
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check pandas_datareader`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt
