### PR TITLE
fix exception for no data with `YahooDailyReader`

### DIFF
--- a/pandas_datareader/yahoo/daily.py
+++ b/pandas_datareader/yahoo/daily.py
@@ -149,7 +149,7 @@ class YahooDailyReader(_DailyBaseReader):
         try:
             j = json.loads(re.search(ptrn, resp.text, re.DOTALL).group(1))
             data = j["context"]["dispatcher"]["stores"]["HistoricalPriceStore"]
-        except KeyError as exc:
+        except (KeyError, AttributeError) as exc:
             msg = "No data fetched for symbol {} using {}"
             raise RemoteDataError(msg.format(symbol, self.__class__.__name__)) from exc
 


### PR DESCRIPTION
addresses issue when data are not found in requested page, to reproduce:
```py
import pandas_datareader.data as web

# Fetch stock data using pandas_datareader
def fetch_stock_data(symbol='AAPL', start_date='2020-01-01', end_date='2021-01-01'):
    df = web.DataReader(symbol, 'yahoo', start_date, end_date)
    return df['Close'].values

print(fetch_stock_data())
```
