### PR TITLE
add dependency of distutils by installing setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Using pandas datareader requires the following packages:
 -   pandas>=1.5.3
 -   lxml
 -   requests>=2.19.0
+-   distutils (not included in standard library of Python 3.12 and above it, which can be solved by installing `setuptools`)
 
 Building the documentation additionally requires:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 pandas>=1.5.3
 requests>=2.19.0
+setuptools


### PR DESCRIPTION
- [✅] closes #xxxx
- [✅] tests added / passed
- [✅] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [✅] passes `black --check pandas_datareader`
- [✅] added entry to docs/source/whatsnew/vLATEST.txt

Add dependency of distutils by installing setuptools, which is not included in standard library in Python 3.12 and above.