### PR TITLE
Vendor deprecate_kwarg to fix pandas 3.0 ImportError (#1005)

### DIFF
--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -1,6 +1,8 @@
+from functools import wraps
 from io import StringIO
 import sys
 from urllib.error import HTTPError
+import warnings
 
 from pandas.api.types import is_list_like, is_number
 from pandas.io import common as com
@@ -9,12 +11,82 @@ from pandas.testing import assert_frame_equal
 __all__ = [
     "HTTPError",
     "StringIO",
+    "deprecate_kwarg",
     "get_filepath_or_buffer",
     "assert_frame_equal",
     "is_list_like",
     "is_number",
     "PYTHON_LT_3_10",
 ]
+
+
+def deprecate_kwarg(old_arg_name, new_arg_name, mapping=None, stacklevel=2):
+    """
+    Decorator to deprecate a keyword argument of a function.
+
+    Vendored from pandas.util._decorators to avoid relying on a private pandas
+    API removed in pandas 3.0 (pandas-datareader issue #1005).
+
+    Parameters
+    ----------
+    old_arg_name : str
+        Name of argument to deprecate.
+    new_arg_name : str or None
+        Replacement argument name. Pass None to warn without renaming.
+    mapping : dict or callable, optional
+        Translate old argument values to new ones.
+    stacklevel : int, default 2
+        Passed to warnings.warn.
+    """
+    if mapping is not None and not hasattr(mapping, "get") and not callable(mapping):
+        raise TypeError(
+            "mapping from old to new argument values must be dict or callable!"
+        )
+
+    def _decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            old_arg_value = kwargs.pop(old_arg_name, None)
+
+            if old_arg_value is not None:
+                if new_arg_name is None:
+                    msg = (
+                        f"the {repr(old_arg_name)} keyword is deprecated and "
+                        "will be removed in a future version. Please take "
+                        f"steps to stop the use of {repr(old_arg_name)}"
+                    )
+                    warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
+                    kwargs[old_arg_name] = old_arg_value
+                    return func(*args, **kwargs)
+                elif mapping is not None:
+                    if callable(mapping):
+                        new_arg_value = mapping(old_arg_value)
+                    else:
+                        new_arg_value = mapping.get(old_arg_value, old_arg_value)
+                    msg = (
+                        f"the {old_arg_name}={repr(old_arg_value)} keyword is "
+                        f"deprecated, use {new_arg_name}={repr(new_arg_value)} instead."
+                    )
+                else:
+                    new_arg_value = old_arg_value
+                    msg = (
+                        f"the {repr(old_arg_name)} keyword is deprecated, "
+                        f"use {repr(new_arg_name)} instead."
+                    )
+
+                warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
+                if kwargs.get(new_arg_name) is not None:
+                    msg = (
+                        f"Can only specify {repr(old_arg_name)} "
+                        f"or {repr(new_arg_name)}, not both."
+                    )
+                    raise TypeError(msg)
+                kwargs[new_arg_name] = new_arg_value
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return _decorator
 
 
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None, compression=None):

--- a/pandas_datareader/data.py
+++ b/pandas_datareader/data.py
@@ -6,7 +6,7 @@ Module contains tools for collecting data from various remote sources
 
 import warnings
 
-from pandas.util._decorators import deprecate_kwarg
+from pandas_datareader.compat import deprecate_kwarg
 
 from pandas_datareader.av.forex import AVForexReader
 from pandas_datareader.av.quotes import AVQuotesReader

--- a/pandas_datareader/tests/test_deprecate_kwarg.py
+++ b/pandas_datareader/tests/test_deprecate_kwarg.py
@@ -1,0 +1,108 @@
+"""
+Regression tests for issue #1005:
+pandas-datareader imported deprecate_kwarg from the private internal API
+pandas.util._decorators, which is being removed in pandas 3.0.
+
+Fix: vendor the implementation in pandas_datareader.compat so there is no
+dependency on a private pandas API.
+"""
+import warnings
+import pytest
+from pandas_datareader.compat import deprecate_kwarg
+
+
+class TestDeprecateKwarg:
+
+    def test_old_kwarg_warns_and_maps_to_new(self):
+        @deprecate_kwarg("access_key", "api_key")
+        def f(api_key=None):
+            return api_key
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = f(access_key="abc")
+
+        assert result == "abc"
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert "access_key" in str(w[0].message)
+        assert "api_key" in str(w[0].message)
+
+    def test_new_kwarg_passes_without_warning(self):
+        @deprecate_kwarg("old", "new")
+        def f(new=None):
+            return new
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = f(new="value")
+
+        assert result == "value"
+        assert len(w) == 0
+
+    def test_both_old_and_new_raises_type_error(self):
+        @deprecate_kwarg("old", "new")
+        def f(new=None):
+            return new
+
+        with pytest.raises(TypeError, match="Can only specify"):
+            f(old="a", new="b")
+
+    def test_mapping_dict_translates_value(self):
+        @deprecate_kwarg("old", "new", mapping={"yes": True, "no": False})
+        def f(new=None):
+            return new
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = f(old="yes")
+
+        assert result is True
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+
+    def test_mapping_callable_translates_value(self):
+        @deprecate_kwarg("old", "new", mapping=lambda x: x.upper())
+        def f(new=None):
+            return new
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = f(old="hello")
+
+        assert result == "HELLO"
+        assert len(w) == 1
+
+    def test_new_arg_name_none_warns_and_keeps_old(self):
+        @deprecate_kwarg("old_param", None)
+        def f(old_param=None):
+            return old_param
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = f(old_param="val")
+
+        assert result == "val"
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+
+    def test_invalid_mapping_type_raises(self):
+        with pytest.raises(TypeError, match="mapping from old to new"):
+            deprecate_kwarg("old", "new", mapping="invalid")
+
+    def test_import_does_not_use_private_pandas_api(self):
+        """Ensure data.py no longer imports from pandas.util._decorators."""
+        import ast
+        import pathlib
+
+        data_src = (
+            pathlib.Path(__file__).parent.parent / "data.py"
+        ).read_text()
+        tree = ast.parse(data_src)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                src = ast.unparse(node)
+                assert "pandas.util._decorators" not in src, (
+                    f"data.py still imports from private pandas API: {src}"
+                )


### PR DESCRIPTION
## Summary

Fixes #1005 — `pandas-datareader` imported `deprecate_kwarg` from `pandas.util._decorators`, a private internal API that is being removed in pandas 3.0. This causes an `ImportError` on pandas >= 3.0, breaking every import of the library.

## Root cause

```python
# pandas_datareader/data.py
from pandas.util._decorators import deprecate_kwarg  # private API, removed in pandas 3.0
```

## Fix

Vendor the `deprecate_kwarg` implementation directly into `pandas_datareader.compat` (matching the behaviour of the pandas original), and update `data.py` to import from there:

```python
# pandas_datareader/data.py
from pandas_datareader.compat import deprecate_kwarg  # no private pandas dependency
```

The vendored implementation in `compat/__init__.py` is a faithful port of the pandas original, supporting:
- Simple old → new kwarg rename with FutureWarning
- `mapping` dict or callable for value translation
- `TypeError` when both old and new kwargs are passed simultaneously
- `new_arg_name=None` for pure deprecation warnings

## Test plan

- [x] 8 new unit tests in `tests/test_deprecate_kwarg.py` covering all decorator behaviours
- [x] One AST-based test asserting `data.py` no longer references `pandas.util._decorators`
- [x] All 8 tests pass on Python 3.9 with pandas 2.x